### PR TITLE
fix: warmup error handling + timeout (issue #22)

### DIFF
--- a/run_backtest.py
+++ b/run_backtest.py
@@ -1004,6 +1004,7 @@ class BacktestApp:
         self._live_poll_id = None  # root.after() id for cancellation
         self._live_warmup_mode: bool = False
         self._live_warmup_data: list[str] = []
+        self._warmup_timeout_id = None
         self._live_polling: bool = False
         self._live_poll_data: list[str] = []
         # Tick-based live data feed
@@ -3723,7 +3724,7 @@ class BacktestApp:
     def _on_live_warmup_complete(self):
         """Called when COM warmup KLine data is complete."""
         self._live_warmup_mode = False
-        if getattr(self, '_warmup_timeout_id', None):
+        if self._warmup_timeout_id:
             self.root.after_cancel(self._warmup_timeout_id)
             self._warmup_timeout_id = None
 
@@ -4566,7 +4567,7 @@ class BacktestApp:
             self._reconnect_timer_id = None
         self._reconnect_attempt = 0
 
-        if getattr(self, '_warmup_timeout_id', None):
+        if self._warmup_timeout_id:
             self.root.after_cancel(self._warmup_timeout_id)
             self._warmup_timeout_id = None
         self._live_warmup_mode = False


### PR DESCRIPTION
## Summary
- **Root cause**: `RequestKLineAMByDate` returns error codes in 1000-2999 range (e.g. 1095), but the check only caught codes >= 3000. This silently left `_live_warmup_mode=True` forever, hanging the bot in WARMING_UP state.
- Catch ALL non-zero return codes and show them in the live log
- Add 30-second safety timeout — if `OnKLineComplete` never fires, stop gracefully instead of hanging

## Test plan
- [x] All 430 existing tests pass
- [ ] Deploy TMF00 bot — if warmup fails, error code should be displayed and bot stops
- [ ] Deploy TX00 bot — warmup should complete normally (timeout does not interfere)

Fixes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)