### PR TITLE
feat(daily-report): Phase A — daily report pipeline + market regime classifier

### DIFF
--- a/docs/phase-a-daily-report.md
+++ b/docs/phase-a-daily-report.md
@@ -1,0 +1,639 @@
+# Phase A: Daily Report Pipeline + Market Regime Classifier
+
+## 1. Overview
+
+Phase A is the **data foundation** for an automated strategy refinement system. The
+full system will eventually run a closed loop:
+
+```
+Phase A (this PR)     Phase B (planned)        Phase C (planned)
+  Daily Reports    ->  Walk-Forward Validator -> AI Diagnosis & Tuning
+  Regime Classifier    Out-of-sample testing     Automated param tweaks
+  Strategy Changelog   Performance grading       Feedback into changelog
+```
+
+Phase A answers the question: **"What happened today, and what was the market
+doing?"** It produces structured, machine-readable data that Phase B and C
+will consume to evaluate strategy fitness and propose improvements.
+
+### What Phase A provides
+
+| Component | Purpose |
+|-----------|---------|
+| **Daily Report Generator** | Per-day JSON reports with trade details, summary metrics, and market context |
+| **Market Regime Classifier** | Labels the current market state (trending, range-bound, volatile, etc.) using ADX/ATR/EMA |
+| **Strategy Changelog** | Audit trail of every strategy parameter change with before/after metrics |
+| **CLI** | Command-line interface to list and view saved reports |
+| **Discord Integration** | Posts daily report summaries to a Discord channel |
+
+### What Phase A does NOT do (yet)
+
+- It does not automatically trigger at the end of each trading session (that's a Phase B integration)
+- It does not analyze whether a strategy should change (Phase C)
+- It does not modify strategy parameters (Phase C)
+
+
+## 2. What Triggers the Daily Report
+
+### Automatic: LiveRunner post-session (built-in)
+
+When `LiveRunner.stop()` is called — either by the user clicking "Stop Bot"
+or by the GUI's end-of-session logic — it **automatically generates a daily
+report** before releasing resources. The call chain is:
+
+```
+LiveRunner.stop()
+  -> self._auto_save_session()      # save broker state
+  -> self._generate_daily_report()  # NEW: auto-generate report
+  -> self.csv_logger.close()        # close log files
+  -> self.release_lock()
+  -> state = STOPPED
+```
+
+The report is written to `data/daily-reports/YYYY-MM-DD.json` and an
+`on_daily_report` event is emitted so the GUI can forward it to Discord or
+display it. This is best-effort — if report generation fails for any reason,
+it is silently caught and the bot stop proceeds normally.
+
+The data used:
+- **Trades**: from `self.broker.trades` (the same `SimulatedBroker` used by
+  the strategy during the session)
+- **Bar data**: from `self.data_store` (highs/lows/closes for regime
+  classification)
+- **Metadata**: `strategy_display_name`, `point_value`, `symbol` — all
+  already available on the `LiveRunner` instance
+
+### Manual: from backtest results
+
+After running a backtest, call `generate_report_from_backtest()` with the
+engine's output:
+
+```python
+reports = generate_report_from_backtest(
+    trades=result.trades,
+    equity_curve=result.equity_curve,
+    bars_highs=[b.high for b in bars],
+    bars_lows=[b.low for b in bars],
+    bars_closes=[b.close for b in bars],
+    strategy_name="H4 Bollinger Long",
+    point_value=200,
+    symbol="TXF1",
+)
+```
+
+This splits all trades by exit date and writes one report per day.
+
+### Hooking into Discord
+
+To send the report to Discord when the live bot stops, listen for the
+`on_daily_report` event:
+
+```python
+runner.on("on_daily_report", lambda report: discord_notifier.daily_report(report))
+```
+
+The GUI can wire this up at deployment time alongside the existing Discord
+notifier setup.
+
+
+## 3. Strategy Compatibility
+
+### Short answer: works with ANY strategy
+
+The report generator consumes `list[Trade]` from `src.backtest.broker.Trade`.
+Every strategy in the system — whether hand-written, AI-generated, or loaded
+from the strategy store — produces trades through the same `SimulatedBroker`
+and therefore outputs the same `Trade` dataclass.
+
+### Strategy types that are compatible
+
+| Strategy type | How it produces trades | Compatible? |
+|---------------|----------------------|-------------|
+| `BacktestStrategy` subclass (e.g. `H4BollingerLong`) | Calls `broker.entry()`/`exit()`/`close()` directly | Yes |
+| `AbstractStrategy` subclass (via `SignalStrategyAdapter`) | Returns `Signal` objects, adapter maps to broker calls | Yes |
+| AI-generated strategies (from the Workbench) | Generated code calls `broker.entry()`/`exit()`/`close()` | Yes |
+| Live deployed strategies | Same `SimulatedBroker` instance in `LiveRunner` | Yes |
+
+### Trade dataclass fields the report uses
+
+```python
+@dataclass
+class Trade:
+    tag: str              # Entry order name (e.g. "Long", "Short")
+    side: OrderSide       # LONG or SHORT
+    qty: int              # Position size
+    entry_price: int      # Entry fill price (raw integer)
+    exit_price: int       # Exit fill price (raw integer)
+    entry_bar_index: int  # Bar index at entry
+    exit_bar_index: int   # Bar index at exit
+    pnl: int              # Realized P&L in points
+    exit_tag: str         # What triggered exit ("limit", "stop", "close", "force_close")
+    entry_dt: str         # "YYYY-MM-DD HH:MM" format
+    exit_dt: str          # "YYYY-MM-DD HH:MM" format
+    real_entry_price: int # Broker-confirmed fill (live mode only, 0 if paper)
+    real_exit_price: int  # (not yet captured)
+```
+
+All fields are populated by `SimulatedBroker` during both backtesting and live
+trading. The report generator uses every field above. `exit_dt` is required for
+date grouping — trades without `exit_dt` (i.e. still open) are excluded from
+reports.
+
+### Graceful field handling
+
+The report generator uses `getattr()` with defaults for every field, so it
+will not crash if a trade object is missing optional fields:
+
+| Field | Required? | What happens if missing/zero |
+|-------|-----------|----------------------------|
+| `tag` | No | Empty string in report |
+| `side` | Yes | Falls back to `str(side)` if not an enum |
+| `qty` | No | Defaults to 1 |
+| `entry_price`, `exit_price` | No | Defaults to 0 |
+| `entry_dt`, `exit_dt` | Soft | Empty string; trade excluded from date grouping if `exit_dt` is empty |
+| `pnl` | No | Defaults to 0 |
+| `entry_bar_index`, `exit_bar_index` | No | Defaults to 0; `bars_held` = 0 |
+| `exit_tag` | No | Empty string |
+| `real_entry_price`, `real_exit_price` | No | Shows as `null` in JSON (paper mode or unconfirmed) |
+
+### Assumptions
+
+- **Prices are raw integers** as returned by the Capital API (TAIFEX convention).
+  The `point_value` parameter on the report generator converts raw P&L to
+  currency P&L (e.g. `pnl * 200` for TX futures, `pnl * 50` for MTX).
+- **`exit_dt` should be a string starting with "YYYY-MM-DD"**. This is the
+  format `SimulatedBroker` produces. Trades without a valid `exit_dt` are
+  excluded from date-grouped reports but do not cause errors.
+- **Bar data for regime classification** (highs/lows/closes as `list[int]`)
+  is optional. If not provided (or if `DataStore` raises an error), the
+  `market_regime` field in the report is `null`.
+
+
+## 4. How to Run It
+
+### Prerequisites
+
+**No new dependencies.** Phase A uses only the standard library (`json`,
+`pathlib`, `dataclasses`, `argparse`, `math`) plus existing project modules
+(`src.backtest.broker`, `src.backtest.metrics`, `src.strategy.indicators`).
+
+### Automatic generation (live trading)
+
+When you deploy a live bot and later stop it (via the GUI or session end),
+the daily report is generated automatically. No setup required.
+
+The report file appears at `data/daily-reports/YYYY-MM-DD.json` and an
+`on_daily_report` event fires so the GUI can display it or forward to Discord.
+
+### CLI commands
+
+All commands are run from the project root directory.
+
+#### List available reports
+
+```bash
+python -m src.daily_report --list
+```
+
+Output:
+```
+Available reports (3):
+  2026-04-09
+  2026-04-10
+  2026-04-11
+```
+
+#### View a specific report
+
+```bash
+python -m src.daily_report --date 2026-04-11 --show
+```
+
+Output (truncated):
+```json
+{
+  "date": "2026-04-11",
+  "symbol": "TXF1",
+  "generated_at": "2026-04-11 14:30:00",
+  "strategy": {
+    "name": "H4 Bollinger Long",
+    "version": "2.1",
+    "params": {"bb_period": 20, "bb_std": 2.0}
+  },
+  "trades": [
+    {
+      "tag": "Long",
+      "side": "LONG",
+      "qty": 1,
+      "entry_price": 22450,
+      "exit_price": 22520,
+      "entry_dt": "2026-04-11 09:15",
+      "exit_dt": "2026-04-11 11:30",
+      "pnl": 70,
+      "pnl_currency": 14000,
+      "bars_held": 9,
+      "exit_tag": "limit",
+      "real_entry_price": null,
+      "real_exit_price": null
+    }
+  ],
+  "summary": {
+    "total_trades": 1,
+    "winning_trades": 1,
+    "losing_trades": 0,
+    "win_rate": 1.0,
+    "total_pnl": 70,
+    "profit_factor": "Infinity",
+    "max_drawdown": 0,
+    ...
+  },
+  "market_regime": {
+    "label": "trending-up",
+    "trend_strength": "trending",
+    "volatility": "normal",
+    "direction": "bullish",
+    "adx": 32.45,
+    "plus_di": 28.12,
+    "minus_di": 14.33,
+    "atr": 85.6,
+    "atr_ratio": 1.05,
+    "ema_50": 22380.5,
+    "last_close": 22520
+  }
+}
+```
+
+#### Default (no flags)
+
+```bash
+python -m src.daily_report --date 2026-04-11
+```
+
+If a report already exists for that date, prints a message to use `--show`.
+Otherwise, tells you reports are generated by the backtest engine or live runner.
+
+### Generating reports programmatically
+
+#### From a backtest result
+
+```python
+from src.daily_report import generate_report_from_backtest
+
+# After running BacktestEngine.run(bars):
+reports = generate_report_from_backtest(
+    trades=result.trades,
+    equity_curve=result.equity_curve,
+    bars_highs=[b.high for b in bars],
+    bars_lows=[b.low for b in bars],
+    bars_closes=[b.close for b in bars],
+    strategy_name="H4 Bollinger Long",
+    strategy_version="2.1",
+    strategy_params={"bb_period": 20, "bb_std": 2.0},
+    point_value=200,       # TX futures
+    symbol="TXF1",
+)
+# Returns a list of dicts, one per trading day
+# Files saved to data/daily-reports/YYYY-MM-DD.json
+```
+
+#### From live trading (single day)
+
+```python
+from src.daily_report import generate_daily_report
+
+report = generate_daily_report(
+    date="2026-04-11",
+    trades=broker.trades,  # today's closed trades
+    bars_highs=highs_list,
+    bars_lows=lows_list,
+    bars_closes=closes_list,
+    strategy_name="M1 SMA Cross",
+    strategy_version="1.0",
+    strategy_params={"fast": 3, "slow": 8},
+    point_value=50,        # MTX futures
+    symbol="TMF1",
+)
+```
+
+### Where reports are stored
+
+```
+data/
+  daily-reports/
+    2026-04-09.json
+    2026-04-10.json
+    2026-04-11.json
+  changelog.json
+```
+
+The `data/` directory is gitignored. Reports persist locally on the machine
+running the bot.
+
+### Discord integration
+
+The existing `DiscordNotifier` class now has a `daily_report()` method. If you
+already have Discord configured in `settings.yaml` (with `bot_token` and
+`channel_id`), you can send a report summary:
+
+```python
+from src.live.discord_notify import DiscordNotifier
+
+notifier = DiscordNotifier(
+    bot_token="your-bot-token",
+    channel_id="your-channel-id",
+    bot_name="MyBot",
+    symbol="TXF1",
+)
+notifier.daily_report(report)  # pass the dict from generate_daily_report()
+```
+
+The Discord message includes: date, strategy name, trade count, win rate,
+profit factor, P&L, max drawdown, and the regime label (if available).
+
+There is no standalone `/report` Discord slash command yet. The `daily_report()`
+method is a fire-and-forget REST call, same pattern as the existing
+`order_sent()`, `fill_confirmed()`, etc.
+
+
+## 5. Market Regime Classifier
+
+### How it works
+
+The classifier takes bar data (highs, lows, closes as integer lists) and
+computes three independent dimensions:
+
+```
+                    ┌─────────────────────────┐
+   Bar data ------->│  ADX (14-period)        │-----> Trend strength
+   (H, L, C)       │  +DI, -DI               │       trending / range-bound / transitional
+                    ├─────────────────────────┤
+                    │  ATR (14-period)        │-----> Volatility
+                    │  ATR ratio = curr / avg │       high / normal / low
+                    ├─────────────────────────┤
+                    │  EMA (50-period)        │-----> Direction
+                    │  close vs EMA           │       bullish / bearish
+                    └─────────────────────────┘
+                              │
+                              v
+                    ┌─────────────────────────┐
+                    │  Combine into label     │
+                    └─────────────────────────┘
+```
+
+### Trend strength (ADX)
+
+| ADX value | Classification |
+|-----------|---------------|
+| > 25 | **Trending** — strong directional movement |
+| < 20 | **Range-bound** — no clear trend |
+| 20-25 | **Transitional** — trend emerging or fading |
+
+### Volatility (ATR ratio)
+
+ATR ratio = current ATR(14) / average of the last 20 ATR values.
+
+| ATR ratio | Classification |
+|-----------|---------------|
+| > 1.3 | **High** — volatility spike, 30%+ above recent average |
+| < 0.7 | **Low** — unusually quiet, 30%+ below recent average |
+| 0.7-1.3 | **Normal** — within typical range |
+
+### Direction (EMA)
+
+| Close vs EMA(50) | Classification |
+|-------------------|---------------|
+| Close >= EMA | **Bullish** |
+| Close < EMA | **Bearish** |
+
+### Combined regime labels
+
+The three dimensions combine according to these priority rules:
+
+| Regime label | When assigned |
+|-------------|---------------|
+| `high-volatility` | ATR ratio > 1.3 (overrides trend/direction) |
+| `trending-up` | ADX > 25 and bullish, normal/low volatility |
+| `trending-down` | ADX > 25 and bearish, normal/low volatility |
+| `range-bound` | ADX < 20, normal volatility |
+| `low-volatility-chop` | ADX < 20 and ATR ratio < 0.7 |
+| `transitional-bullish` | ADX 20-25, bullish, normal/low volatility |
+| `transitional-bearish` | ADX 20-25, bearish, normal/low volatility |
+
+High volatility takes top priority because it signals a regime that affects all
+strategies regardless of trend/direction.
+
+### Raw indicator values
+
+Every `RegimeResult` includes the raw values so that downstream AI analysis
+(Phase C) can make nuanced decisions beyond the simple label:
+
+- `adx` — trend strength 0-100
+- `plus_di` — bullish directional pressure 0-100
+- `minus_di` — bearish directional pressure 0-100
+- `atr` — current Average True Range (raw integer, same scale as prices)
+- `atr_ratio` — current ATR / 20-bar trailing average ATR
+- `ema_50` — 50-period EMA value
+- `last_close` — most recent closing price
+
+### Data requirements
+
+The classifier requires enough bars for the longest lookback:
+- ADX(14) needs at least `2 * 14 + 1 = 29` bars
+- EMA(50) needs at least 50 bars
+- ATR ratio needs `14 + 1 + 20 = 35` bars for the trailing average
+
+**Minimum: 50 bars.** If insufficient data is provided, `classify_regime()`
+returns `None`.
+
+### Customizing periods
+
+```python
+from src.daily_report import classify_regime
+
+result = classify_regime(
+    highs, lows, closes,
+    adx_period=20,       # default 14
+    atr_period=20,       # default 14
+    ema_period=100,      # default 50
+    atr_avg_period=30,   # default 20
+)
+```
+
+
+## 6. Strategy Changelog
+
+### How it works
+
+The changelog is an append-only JSON array in `data/changelog.json`. Each entry
+records a strategy modification with enough context for Phase C's AI to
+understand the history of changes and their effects.
+
+### Entry structure
+
+```json
+{
+  "date": "2026-04-11 14:30:00",
+  "strategy": "H4 Bollinger Long",
+  "version_before": "2.0",
+  "version_after": "2.1",
+  "change_summary": "Tightened stop loss from 2x ATR to 1.5x ATR",
+  "initiated_by": "ai",
+  "metrics_before": {
+    "win_rate": 0.45,
+    "profit_factor": 1.2,
+    "max_drawdown": 5000
+  },
+  "metrics_after": {
+    "win_rate": 0.50,
+    "profit_factor": 1.5,
+    "max_drawdown": 3500
+  },
+  "params_before": {"atr_mult": 2.0},
+  "params_after": {"atr_mult": 1.5}
+}
+```
+
+### API
+
+```python
+from src.daily_report import append_changelog, load_changelog, recent_changes
+
+# Record a change
+append_changelog(
+    strategy_name="H4 Bollinger Long",
+    version_before="2.0",
+    version_after="2.1",
+    change_summary="Tightened stop loss from 2x ATR to 1.5x ATR",
+    initiated_by="ai",            # or "human"
+    metrics_before={"win_rate": 0.45, "profit_factor": 1.2},
+    metrics_after={"win_rate": 0.50, "profit_factor": 1.5},
+    params_before={"atr_mult": 2.0},
+    params_after={"atr_mult": 1.5},
+)
+
+# Read all entries
+all_entries = load_changelog()     # list[dict], chronological order
+
+# Get last N entries (newest first)
+last_5 = recent_changes(n=5)      # list[dict], reverse chronological
+```
+
+### Storage
+
+- **File**: `data/changelog.json` (gitignored, local to the machine)
+- **Format**: JSON array, pretty-printed with 2-space indent, UTF-8
+- **Resilience**: if the file is corrupted or contains non-array JSON,
+  `load_changelog()` returns an empty list instead of raising an exception
+
+
+## 7. Configuration
+
+### No new configuration required
+
+Phase A introduces **no new config files, environment variables, or
+settings.yaml entries**. It uses:
+
+- Existing project structure (`data/` directory for output)
+- Existing indicator implementations from `src/strategy/indicators/`
+- Existing `Trade` dataclass from `src/backtest/broker`
+- Existing `calculate_metrics()` from `src/backtest/metrics`
+- Existing Discord notifier pattern from `src/live/discord_notify`
+
+### Optional: Discord setup
+
+If you want Discord report notifications, ensure `settings.yaml` has:
+
+```yaml
+discord:
+  bot_token: "your-discord-bot-token"
+  channel_id: "your-channel-id"
+```
+
+This is the same configuration the live trading bot already uses for order
+and fill notifications. No additional Discord setup is needed.
+
+### Report output directory
+
+Reports are written to `data/daily-reports/`. This directory is created
+automatically on first report generation. It lives under the gitignored
+`data/` directory, so reports stay local.
+
+
+## 8. Architecture Diagram
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                        tai-robot system                             │
+│                                                                     │
+│  ┌──────────────┐     ┌──────────────┐     ┌──────────────────┐    │
+│  │   Backtest    │     │  Live Runner  │     │  AI Workbench    │    │
+│  │   Engine      │     │  (LiveRunner) │     │  (code gen)      │    │
+│  │              │     │              │     │                  │    │
+│  │  (manual     │     │  stop() AUTO │     │                  │    │
+│  │   call)      │     │  triggers    │     │                  │    │
+│  └──────┬───────┘     └──────┬───────┘     └────────┬─────────┘    │
+│         │                    │                       │              │
+│         │  list[Trade]       │  list[Trade]          │ param change │
+│         │  list[Bar]         │  list[Bar]            │              │
+│         v                    v                       v              │
+│  ┌──────────────────────────────────────────────────────────────┐   │
+│  │              src/daily_report/  (Phase A)                    │   │
+│  │                                                              │   │
+│  │  ┌────────────────────┐    ┌──────────────────────────────┐ │   │
+│  │  │  report_generator   │    │  regime_classifier           │ │   │
+│  │  │                    │    │                              │ │   │
+│  │  │  generate_daily_   │    │  classify_regime(H, L, C)    │ │   │
+│  │  │  report()     ─────┼───>│    ├─ ADX(14) -> trend       │ │   │
+│  │  │                    │    │    ├─ ATR ratio -> volatility │ │   │
+│  │  │  generate_report_  │    │    └─ EMA(50) -> direction   │ │   │
+│  │  │  from_backtest()   │    │                              │ │   │
+│  │  │                    │    │  Returns: RegimeResult       │ │   │
+│  │  │  Uses:             │    └──────────────────────────────┘ │   │
+│  │  │  calculate_metrics │                                      │   │
+│  │  │  (from backtest)   │    ┌──────────────────────────────┐ │   │
+│  │  └────────┬───────────┘    │  changelog                   │ │   │
+│  │           │                │                              │ │   │
+│  │           │                │  append_changelog()          │ │   │
+│  │           │                │  load_changelog()            │ │   │
+│  │           │                │  recent_changes(n)           │ │   │
+│  │           │                └──────────────┬───────────────┘ │   │
+│  └───────────┼──────────────────────────────┼──────────────────┘   │
+│              │                               │                      │
+│              v                               v                      │
+│  ┌───────────────────────┐    ┌──────────────────────────────┐     │
+│  │ data/daily-reports/   │    │ data/changelog.json          │     │
+│  │   2026-04-09.json     │    │   [{date, strategy, version  │     │
+│  │   2026-04-10.json     │    │     change_summary, metrics  │     │
+│  │   2026-04-11.json     │    │     params, initiated_by}]   │     │
+│  └───────────┬───────────┘    └──────────────────────────────┘     │
+│              │                                                      │
+│              v                                                      │
+│  ┌───────────────────────┐                                         │
+│  │  Discord Notifier     │                                         │
+│  │  daily_report(report) │───> Discord channel                     │
+│  └───────────────────────┘                                         │
+│                                                                     │
+│  ┌───────────────────────┐                                         │
+│  │  CLI                  │                                         │
+│  │  python -m            │                                         │
+│  │    src.daily_report   │                                         │
+│  │    --show / --list    │                                         │
+│  └───────────────────────┘                                         │
+│                                                                     │
+│  - - - - - - - - - - - - Future phases - - - - - - - - - - - - -   │
+│                                                                     │
+│  ┌───────────────────────┐    ┌──────────────────────────────┐     │
+│  │  Phase B              │    │  Phase C                     │     │
+│  │  Walk-Forward         │    │  AI Diagnosis                │     │
+│  │  Validator            │    │  & Auto-Tuning               │     │
+│  │  (reads daily reports │    │  (reads reports + changelog  │     │
+│  │   + regime data)      │    │   proposes param changes)    │     │
+│  └───────────────────────┘    └──────────────────────────────┘     │
+└─────────────────────────────────────────────────────────────────────┘
+
+Reused existing modules:
+  src/strategy/indicators/  ── adx(), atr(), ema(), plus_di(), minus_di()
+  src/backtest/metrics.py   ── calculate_metrics()
+  src/backtest/broker.py    ── Trade dataclass
+  src/live/discord_notify.py ── DiscordNotifier (extended with daily_report())
+```

--- a/run_backtest.py
+++ b/run_backtest.py
@@ -3562,6 +3562,7 @@ class BacktestApp:
         self._live_runner.on("on_bar", lambda b: self.root.after(0, self._on_live_bar, b))
         self._live_runner.on("on_decision", lambda d: self.root.after(0, self._on_live_decision, d))
         self._live_runner.on("on_status", lambda s: self.root.after(0, self._live_log_msg, s, "status"))
+        self._live_runner.on("on_daily_report", lambda r: self.root.after(0, self._on_live_daily_report, r))
 
         # Set data source for live mode
         self._data_source = "即時交易 Live (tick)"
@@ -4189,6 +4190,22 @@ class BacktestApp:
         # Semi-auto / Auto: handle real orders on fills
         if self._trading_mode in ("semi_auto", "auto") and action in ("ENTRY_FILL", "TRADE_CLOSE", "FORCE_CLOSE"):
             self._handle_semi_auto_order(decision)
+
+    def _on_live_daily_report(self, report: dict) -> None:
+        """Forward end-of-session daily report to Discord and the live log."""
+        date = report.get("date", "?")
+        summary = report.get("summary", {}) or {}
+        self._live_log_msg(
+            f"每日報告已產生 Daily report saved: data/daily-reports/{date}.json "
+            f"({summary.get('total_trades', 0)} trades, "
+            f"P&L {summary.get('total_pnl', 0):+,})",
+            "status",
+        )
+        if _discord is not None and _discord.enabled:
+            try:
+                _discord.daily_report(report)
+            except Exception:
+                pass  # best-effort; never block on notification failure
 
     # ── Semi-auto real order handling ──
 

--- a/run_backtest.py
+++ b/run_backtest.py
@@ -3801,6 +3801,7 @@ class BacktestApp:
         self._update_live_status()
         self._check_tick_watchdog()
         self._check_session_end_close()
+        self._check_session_end_report()
         self._live_poll_id = self.root.after(30000, self._schedule_status_update)
 
     _SESSION_END_CLOSE_MINUTES = 2          # normal session: close 2 min before
@@ -3911,6 +3912,33 @@ class BacktestApp:
             "session_end", last_bar.close, f"auto close {mins}min before session end",
         )
         runner._auto_save_session()
+
+    def _check_session_end_report(self):
+        """Fire the daily-report hook near each session close.
+
+        Runs on the same 30s cadence as ``_check_session_end_close`` and
+        mirrors its settlement-aware threshold (2 min normal, 5 min on
+        settlement day for the front-month). Fires regardless of
+        position state — flat bots still produce a report. Per-session
+        debounce lives inside ``LiveRunner._generate_daily_report``.
+        """
+        if not self._live_runner or self._live_runner.state != LiveState.RUNNING:
+            return
+        order_sym = resolve_order_symbol(self._live_runner.symbol)
+        mins = minutes_until_session_close(order_sym)
+        if mins is None:
+            return
+        try:
+            from src.market_data.holidays import is_settlement_day, is_front_month_contract
+            is_settlement = (is_settlement_day(_taipei_now())
+                             and is_front_month_contract(order_sym, _taipei_now()))
+        except Exception:
+            is_settlement = False
+        threshold = (self._SETTLEMENT_END_CLOSE_MINUTES if is_settlement
+                     else self._SESSION_END_CLOSE_MINUTES)
+        if mins > threshold:
+            return
+        self._live_runner._generate_daily_report()
 
     def _check_tick_watchdog(self):
         """Delegate tick health check to TickWatchdog and act on the result."""

--- a/src/daily_report/__init__.py
+++ b/src/daily_report/__init__.py
@@ -1,5 +1,5 @@
 """Daily report pipeline: trade reports, market regime classification, strategy changelog."""
 
 from .regime_classifier import classify_regime, RegimeResult
-from .report_generator import generate_daily_report, generate_report_from_backtest
+from .report_generator import generate_daily_report, generate_report_from_backtest, generate_session_report
 from .changelog import append_changelog, load_changelog, recent_changes

--- a/src/daily_report/__init__.py
+++ b/src/daily_report/__init__.py
@@ -1,0 +1,5 @@
+"""Daily report pipeline: trade reports, market regime classification, strategy changelog."""
+
+from .regime_classifier import classify_regime, RegimeResult
+from .report_generator import generate_daily_report, generate_report_from_backtest
+from .changelog import append_changelog, load_changelog, recent_changes

--- a/src/daily_report/__main__.py
+++ b/src/daily_report/__main__.py
@@ -1,0 +1,76 @@
+"""CLI entry point: ``python -m src.daily_report --date 2026-04-11``
+
+Generates (or displays) a daily report. When called without --date,
+defaults to today. With --show, prints an existing report instead of
+generating a new one.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime
+
+from .report_generator import load_report, list_reports
+
+
+def _today() -> str:
+    return datetime.now().strftime("%Y-%m-%d")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog="python -m src.daily_report",
+        description="Daily trade report pipeline for tai-robot",
+    )
+    parser.add_argument(
+        "--date", default=_today(),
+        help="Report date in YYYY-MM-DD format (default: today)",
+    )
+    parser.add_argument(
+        "--show", action="store_true",
+        help="Display an existing report instead of generating",
+    )
+    parser.add_argument(
+        "--list", action="store_true", dest="list_reports",
+        help="List all available report dates",
+    )
+
+    args = parser.parse_args()
+
+    if args.list_reports:
+        dates = list_reports()
+        if not dates:
+            print("No reports found.")
+        else:
+            print(f"Available reports ({len(dates)}):")
+            for d in dates:
+                print(f"  {d}")
+        return
+
+    if args.show:
+        report = load_report(args.date)
+        if report is None:
+            print(f"No report found for {args.date}")
+            sys.exit(1)
+        print(json.dumps(report, indent=2, ensure_ascii=False))
+        return
+
+    # Generate mode: load trades from live session data
+    # This is a placeholder — in production, the caller (live runner or
+    # backtest GUI) would invoke generate_daily_report() directly with
+    # the actual trade and bar data. The CLI is mainly for --show/--list.
+    report = load_report(args.date)
+    if report:
+        print(f"Report for {args.date} already exists. Use --show to view it.")
+    else:
+        print(
+            f"No trade data available for {args.date}.\n"
+            f"Reports are generated automatically by the backtest engine\n"
+            f"or live runner. Use --show to view an existing report."
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/daily_report/changelog.py
+++ b/src/daily_report/changelog.py
@@ -1,0 +1,87 @@
+"""Strategy changelog: tracks every strategy change with before/after metrics.
+
+Stored as ``data/changelog.json`` — a JSON array of change entries.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+_CHANGELOG_PATH = Path("data/changelog.json")
+
+
+def _load_raw() -> list[dict]:
+    if not _CHANGELOG_PATH.exists():
+        return []
+    try:
+        data = json.loads(_CHANGELOG_PATH.read_text(encoding="utf-8"))
+        return data if isinstance(data, list) else []
+    except (json.JSONDecodeError, OSError):
+        return []
+
+
+def _save_raw(entries: list[dict]) -> None:
+    _CHANGELOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    _CHANGELOG_PATH.write_text(
+        json.dumps(entries, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+
+def append_changelog(
+    strategy_name: str,
+    version_before: str,
+    version_after: str,
+    change_summary: str,
+    initiated_by: str = "human",
+    metrics_before: dict | None = None,
+    metrics_after: dict | None = None,
+    params_before: dict | None = None,
+    params_after: dict | None = None,
+) -> dict:
+    """Append a new entry to the strategy changelog.
+
+    Parameters
+    ----------
+    strategy_name : human-readable strategy display name
+    version_before / version_after : version strings
+    change_summary : free-text description of what changed
+    initiated_by : "human" or "ai"
+    metrics_before / metrics_after : performance metrics dicts (optional)
+    params_before / params_after : strategy parameter dicts (optional)
+
+    Returns
+    -------
+    dict : the new entry (also persisted to disk)
+    """
+    entries = _load_raw()
+
+    entry = {
+        "date": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+        "strategy": strategy_name,
+        "version_before": version_before,
+        "version_after": version_after,
+        "change_summary": change_summary,
+        "initiated_by": initiated_by,
+        "metrics_before": metrics_before,
+        "metrics_after": metrics_after,
+        "params_before": params_before,
+        "params_after": params_after,
+    }
+
+    entries.append(entry)
+    _save_raw(entries)
+    return entry
+
+
+def load_changelog() -> list[dict]:
+    """Load the full changelog."""
+    return _load_raw()
+
+
+def recent_changes(n: int = 10) -> list[dict]:
+    """Return the most recent *n* changelog entries (newest first)."""
+    entries = _load_raw()
+    return list(reversed(entries[-n:]))

--- a/src/daily_report/regime_classifier.py
+++ b/src/daily_report/regime_classifier.py
@@ -1,0 +1,157 @@
+"""Market regime classifier for Taiwan futures (TAIEX).
+
+Classifies the current market state using ADX, ATR, and EMA indicators.
+All raw indicator values are included in the result for downstream AI analysis.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from src.strategy.indicators import adx, plus_di, minus_di, atr, ema
+
+
+@dataclass
+class RegimeResult:
+    """Market regime classification with raw indicator values."""
+    label: str              # e.g. "trending-up", "range-bound", "high-volatility"
+    trend_strength: str     # "trending", "range-bound", "transitional"
+    volatility: str         # "high", "normal", "low"
+    direction: str          # "bullish", "bearish"
+
+    # Raw indicator values for AI diagnosis
+    adx_value: float
+    plus_di_value: float
+    minus_di_value: float
+    atr_value: float
+    atr_ratio: float        # current ATR / 20-period average ATR
+    ema_50: float
+    last_close: float
+
+    def to_dict(self) -> dict:
+        return {
+            "label": self.label,
+            "trend_strength": self.trend_strength,
+            "volatility": self.volatility,
+            "direction": self.direction,
+            "adx": round(self.adx_value, 2),
+            "plus_di": round(self.plus_di_value, 2),
+            "minus_di": round(self.minus_di_value, 2),
+            "atr": round(self.atr_value, 2),
+            "atr_ratio": round(self.atr_ratio, 4),
+            "ema_50": round(self.ema_50, 2),
+            "last_close": self.last_close,
+        }
+
+
+def _classify_trend(adx_val: float) -> str:
+    if adx_val > 25:
+        return "trending"
+    if adx_val < 20:
+        return "range-bound"
+    return "transitional"
+
+
+def _classify_volatility(atr_ratio: float) -> str:
+    if atr_ratio > 1.3:
+        return "high"
+    if atr_ratio < 0.7:
+        return "low"
+    return "normal"
+
+
+def _classify_direction(last_close: float, ema_val: float) -> str:
+    return "bullish" if last_close >= ema_val else "bearish"
+
+
+def _combine_label(trend: str, volatility: str, direction: str) -> str:
+    """Combine sub-classifications into a single regime label."""
+    if volatility == "high":
+        return "high-volatility"
+    if trend == "range-bound":
+        if volatility == "low":
+            return "low-volatility-chop"
+        return "range-bound"
+    if trend == "transitional":
+        # Lean toward direction but mark as transitional
+        return f"transitional-{direction}"
+    # trending
+    if direction == "bullish":
+        return "trending-up"
+    return "trending-down"
+
+
+def classify_regime(
+    highs: list[int],
+    lows: list[int],
+    closes: list[int],
+    adx_period: int = 14,
+    atr_period: int = 14,
+    ema_period: int = 50,
+    atr_avg_period: int = 20,
+) -> RegimeResult | None:
+    """Classify the current market regime from OHLC data.
+
+    Requires enough bars for the longest lookback (at least 2*adx_period+1
+    and ema_period bars). Returns None if insufficient data.
+
+    Parameters
+    ----------
+    highs, lows, closes : bar data as integer lists
+    adx_period : ADX calculation period (default 14)
+    atr_period : ATR calculation period (default 14)
+    ema_period : EMA lookback for direction (default 50)
+    atr_avg_period : number of trailing ATR values to average for ratio (default 20)
+    """
+    adx_val = adx(highs, lows, closes, adx_period)
+    if adx_val is None:
+        return None
+
+    pdi = plus_di(highs, lows, closes, adx_period)
+    mdi = minus_di(highs, lows, closes, adx_period)
+    if pdi is None or mdi is None:
+        return None
+
+    current_atr = atr(highs, lows, closes, atr_period)
+    if current_atr is None:
+        return None
+
+    ema_val = ema([float(c) for c in closes], ema_period)
+    if ema_val is None:
+        return None
+
+    # Compute ATR ratio: current vs average of trailing ATR values
+    # We calculate ATR on progressively shorter slices to get a trailing series
+    min_atr_len = atr_period + 1 + atr_avg_period
+    if len(highs) >= min_atr_len:
+        trailing_atrs = []
+        for offset in range(atr_avg_period):
+            end = len(highs) - offset
+            val = atr(highs[:end], lows[:end], closes[:end], atr_period)
+            if val is not None:
+                trailing_atrs.append(val)
+        avg_atr = sum(trailing_atrs) / len(trailing_atrs) if trailing_atrs else current_atr
+    else:
+        avg_atr = current_atr
+
+    atr_ratio = current_atr / avg_atr if avg_atr > 0 else 1.0
+    last_close = float(closes[-1])
+
+    trend = _classify_trend(adx_val)
+    vol = _classify_volatility(atr_ratio)
+    direction = _classify_direction(last_close, ema_val)
+    label = _combine_label(trend, vol, direction)
+
+    return RegimeResult(
+        label=label,
+        trend_strength=trend,
+        volatility=vol,
+        direction=direction,
+        adx_value=adx_val,
+        plus_di_value=pdi,
+        minus_di_value=mdi,
+        atr_value=current_atr,
+        atr_ratio=atr_ratio,
+        ema_50=ema_val,
+        last_close=last_close,
+    )

--- a/src/daily_report/report_generator.py
+++ b/src/daily_report/report_generator.py
@@ -20,21 +20,30 @@ _REPORTS_DIR = Path("data/daily-reports")
 
 
 def _trade_to_dict(t: Trade, point_value: int = 1) -> dict:
-    """Convert a Trade to a JSON-serializable dict with computed fields."""
+    """Convert a Trade to a JSON-serializable dict with computed fields.
+
+    Handles missing or default-valued fields gracefully so that trades from
+    any strategy (hand-written, AI-generated, live, backtest) produce valid
+    output even if optional fields were never populated.
+    """
+    side_val = t.side.value if hasattr(t.side, "value") else str(t.side)
+    pnl = getattr(t, "pnl", 0) or 0
+    entry_bar = getattr(t, "entry_bar_index", 0) or 0
+    exit_bar = getattr(t, "exit_bar_index", 0) or 0
     return {
-        "tag": t.tag,
-        "side": t.side.value,
-        "qty": t.qty,
-        "entry_price": t.entry_price,
-        "exit_price": t.exit_price,
-        "entry_dt": t.entry_dt,
-        "exit_dt": t.exit_dt,
-        "pnl": t.pnl,
-        "pnl_currency": t.pnl * point_value if point_value != 1 else t.pnl,
-        "bars_held": t.exit_bar_index - t.entry_bar_index,
-        "exit_tag": t.exit_tag,
-        "real_entry_price": t.real_entry_price or None,
-        "real_exit_price": t.real_exit_price or None,
+        "tag": getattr(t, "tag", ""),
+        "side": side_val,
+        "qty": getattr(t, "qty", 1),
+        "entry_price": getattr(t, "entry_price", 0),
+        "exit_price": getattr(t, "exit_price", 0),
+        "entry_dt": getattr(t, "entry_dt", ""),
+        "exit_dt": getattr(t, "exit_dt", ""),
+        "pnl": pnl,
+        "pnl_currency": pnl * point_value if point_value != 1 else pnl,
+        "bars_held": exit_bar - entry_bar,
+        "exit_tag": getattr(t, "exit_tag", ""),
+        "real_entry_price": getattr(t, "real_entry_price", 0) or None,
+        "real_exit_price": getattr(t, "real_exit_price", 0) or None,
     }
 
 
@@ -160,6 +169,64 @@ def generate_report_from_backtest(
         reports.append(report)
 
     return reports
+
+
+def generate_session_report(
+    broker,
+    data_store,
+    strategy_name: str = "",
+    strategy_params: dict | None = None,
+    point_value: int = 1,
+    symbol: str = "",
+    date: str = "",
+) -> dict | None:
+    """Generate a daily report from a live session's broker and data store.
+
+    This is the convenience entry point called by LiveRunner.stop().
+    Extracts trades and bar data from the live components and delegates to
+    generate_daily_report().
+
+    Returns the report dict, or None if there are no completed trades.
+    """
+    trades = list(getattr(broker, "trades", []))
+    if not trades:
+        return None
+
+    if not date:
+        # Use the exit date of the last trade, or today
+        last_exit = getattr(trades[-1], "exit_dt", "")
+        date = last_exit[:10] if last_exit else datetime.now().strftime("%Y-%m-%d")
+
+    # Extract bar data for regime classification (best-effort)
+    bars_highs = bars_lows = bars_closes = None
+    if data_store is not None:
+        try:
+            bars_highs = data_store.get_highs()
+            bars_lows = data_store.get_lows()
+            bars_closes = data_store.get_closes()
+        except Exception:
+            pass  # regime classification will be skipped
+
+    # Filter to trades that closed on this date
+    day_trades = [
+        t for t in trades
+        if getattr(t, "exit_dt", "")[:10] == date
+    ]
+    if not day_trades:
+        day_trades = trades  # fallback: include all trades
+
+    return generate_daily_report(
+        date=date,
+        trades=day_trades,
+        bars_highs=bars_highs,
+        bars_lows=bars_lows,
+        bars_closes=bars_closes,
+        strategy_name=strategy_name,
+        strategy_params=strategy_params,
+        point_value=point_value,
+        symbol=symbol,
+        save=True,
+    )
 
 
 def load_report(date: str) -> dict | None:

--- a/src/daily_report/report_generator.py
+++ b/src/daily_report/report_generator.py
@@ -1,0 +1,177 @@
+"""Daily report generator: structured JSON reports from trade and bar data.
+
+Generates per-day reports with trade details, daily summary metrics,
+strategy metadata, and market regime context. Reports are stored in
+``data/daily-reports/YYYY-MM-DD.json``.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from datetime import datetime
+from pathlib import Path
+
+from src.backtest.broker import Trade, OrderSide
+from src.backtest.metrics import PerformanceMetrics, calculate_metrics
+from .regime_classifier import classify_regime, RegimeResult
+
+_REPORTS_DIR = Path("data/daily-reports")
+
+
+def _trade_to_dict(t: Trade, point_value: int = 1) -> dict:
+    """Convert a Trade to a JSON-serializable dict with computed fields."""
+    return {
+        "tag": t.tag,
+        "side": t.side.value,
+        "qty": t.qty,
+        "entry_price": t.entry_price,
+        "exit_price": t.exit_price,
+        "entry_dt": t.entry_dt,
+        "exit_dt": t.exit_dt,
+        "pnl": t.pnl,
+        "pnl_currency": t.pnl * point_value if point_value != 1 else t.pnl,
+        "bars_held": t.exit_bar_index - t.entry_bar_index,
+        "exit_tag": t.exit_tag,
+        "real_entry_price": t.real_entry_price or None,
+        "real_exit_price": t.real_exit_price or None,
+    }
+
+
+def _metrics_to_dict(m: PerformanceMetrics) -> dict:
+    return asdict(m)
+
+
+def _group_trades_by_date(trades: list[Trade]) -> dict[str, list[Trade]]:
+    """Group trades by their exit date (YYYY-MM-DD)."""
+    grouped: dict[str, list[Trade]] = {}
+    for t in trades:
+        if not t.exit_dt:
+            continue
+        # exit_dt format: "YYYY-MM-DD HH:MM" or "YYYY-MM-DD HH:MM:SS"
+        date_str = t.exit_dt[:10]
+        grouped.setdefault(date_str, []).append(t)
+    return grouped
+
+
+def generate_daily_report(
+    date: str,
+    trades: list[Trade],
+    bars_highs: list[int] | None = None,
+    bars_lows: list[int] | None = None,
+    bars_closes: list[int] | None = None,
+    strategy_name: str = "",
+    strategy_version: str = "",
+    strategy_params: dict | None = None,
+    point_value: int = 1,
+    symbol: str = "",
+    save: bool = True,
+) -> dict:
+    """Generate a structured daily report for the given date.
+
+    Parameters
+    ----------
+    date : "YYYY-MM-DD" string
+    trades : trades that closed on this date
+    bars_highs/lows/closes : bar data for regime classification (optional)
+    strategy_name : human-readable strategy name
+    strategy_version : strategy version string
+    strategy_params : current parameter dict
+    point_value : contract multiplier (e.g. 200 for TX, 50 for MTX)
+    symbol : trading symbol
+    save : whether to write the report to disk
+
+    Returns
+    -------
+    dict : the complete report structure
+    """
+    # Build equity curve from these trades for metrics
+    equity_curve = []
+    cumulative = 0
+    for t in trades:
+        cumulative += t.pnl
+        equity_curve.append(cumulative)
+
+    metrics = calculate_metrics(trades, equity_curve, initial_balance=0)
+
+    # Market regime (optional — needs bar data)
+    regime: RegimeResult | None = None
+    if bars_highs and bars_lows and bars_closes:
+        regime = classify_regime(bars_highs, bars_lows, bars_closes)
+
+    report = {
+        "date": date,
+        "symbol": symbol,
+        "generated_at": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+        "strategy": {
+            "name": strategy_name,
+            "version": strategy_version,
+            "params": strategy_params or {},
+        },
+        "trades": [_trade_to_dict(t, point_value) for t in trades],
+        "summary": _metrics_to_dict(metrics),
+        "market_regime": regime.to_dict() if regime else None,
+    }
+
+    if save:
+        _REPORTS_DIR.mkdir(parents=True, exist_ok=True)
+        path = _REPORTS_DIR / f"{date}.json"
+        path.write_text(json.dumps(report, indent=2, ensure_ascii=False), encoding="utf-8")
+
+    return report
+
+
+def generate_report_from_backtest(
+    trades: list[Trade],
+    equity_curve: list[int],
+    bars_highs: list[int] | None = None,
+    bars_lows: list[int] | None = None,
+    bars_closes: list[int] | None = None,
+    strategy_name: str = "",
+    strategy_version: str = "",
+    strategy_params: dict | None = None,
+    point_value: int = 1,
+    symbol: str = "",
+    initial_balance: int = 0,
+    save: bool = True,
+) -> list[dict]:
+    """Generate daily reports from a full backtest result.
+
+    Splits trades by exit date and generates one report per day.
+    Returns list of all generated report dicts.
+    """
+    grouped = _group_trades_by_date(trades)
+    reports = []
+
+    for date, day_trades in sorted(grouped.items()):
+        report = generate_daily_report(
+            date=date,
+            trades=day_trades,
+            bars_highs=bars_highs,
+            bars_lows=bars_lows,
+            bars_closes=bars_closes,
+            strategy_name=strategy_name,
+            strategy_version=strategy_version,
+            strategy_params=strategy_params,
+            point_value=point_value,
+            symbol=symbol,
+            save=save,
+        )
+        reports.append(report)
+
+    return reports
+
+
+def load_report(date: str) -> dict | None:
+    """Load a previously saved daily report. Returns None if not found."""
+    path = _REPORTS_DIR / f"{date}.json"
+    if not path.exists():
+        return None
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def list_reports() -> list[str]:
+    """List all available report dates, sorted ascending."""
+    if not _REPORTS_DIR.exists():
+        return []
+    return sorted(p.stem for p in _REPORTS_DIR.glob("*.json"))

--- a/src/daily_report/report_generator.py
+++ b/src/daily_report/report_generator.py
@@ -63,6 +63,14 @@ def _group_trades_by_date(trades: list[Trade]) -> dict[str, list[Trade]]:
     return grouped
 
 
+def _app_version() -> str:
+    try:
+        from version import APP_VERSION
+        return APP_VERSION
+    except Exception:
+        return ""
+
+
 def generate_daily_report(
     date: str,
     trades: list[Trade],
@@ -74,6 +82,8 @@ def generate_daily_report(
     strategy_params: dict | None = None,
     point_value: int = 1,
     symbol: str = "",
+    bot_name: str = "",
+    started_at: str = "",
     save: bool = True,
 ) -> dict:
     """Generate a structured daily report for the given date.
@@ -88,6 +98,8 @@ def generate_daily_report(
     strategy_params : current parameter dict
     point_value : contract multiplier (e.g. 200 for TX, 50 for MTX)
     symbol : trading symbol
+    bot_name : live bot session identifier (folder suffix), empty for backtests
+    started_at : ISO timestamp of when the live session started
     save : whether to write the report to disk
 
     Returns
@@ -112,6 +124,11 @@ def generate_daily_report(
         "date": date,
         "symbol": symbol,
         "generated_at": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+        "session": {
+            "bot_name": bot_name,
+            "started_at": started_at,
+            "version": _app_version(),
+        },
         "strategy": {
             "name": strategy_name,
             "version": strategy_version,
@@ -179,6 +196,8 @@ def generate_session_report(
     point_value: int = 1,
     symbol: str = "",
     date: str = "",
+    bot_name: str = "",
+    started_at: str = "",
 ) -> dict | None:
     """Generate a daily report from a live session's broker and data store.
 
@@ -225,6 +244,8 @@ def generate_session_report(
         strategy_params=strategy_params,
         point_value=point_value,
         symbol=symbol,
+        bot_name=bot_name,
+        started_at=started_at,
         save=True,
     )
 

--- a/src/live/discord_notify.py
+++ b/src/live/discord_notify.py
@@ -132,6 +132,7 @@ class DiscordNotifier:
         summary = report.get("summary", {})
         regime = report.get("market_regime")
         strategy = report.get("strategy", {})
+        session = report.get("session") or {}
 
         total = summary.get("total_trades", 0)
         pnl = summary.get("total_pnl", 0)
@@ -142,10 +143,32 @@ class DiscordNotifier:
         lines = [
             f"{self._header()}",
             f"📊 **每日報告 Daily Report** — {date}",
+        ]
+
+        # Session identifier line: bot_name + version + start time so the
+        # report stands on its own when read out of context (e.g. saved
+        # JSON, archived Discord logs). bot_name is also in _header() but
+        # belongs in the body for readers who land on the message alone.
+        session_parts: list[str] = []
+        bot = session.get("bot_name") or ""
+        version = session.get("version") or ""
+        started = session.get("started_at") or ""
+        if bot:
+            session_parts.append(f"機器人 Bot: `{bot}`")
+        if version:
+            session_parts.append(f"v{version}")
+        if started:
+            # ISO "2026-04-27T15:02:30" → "2026-04-27 15:02"
+            started_short = started.replace("T", " ")[:16]
+            session_parts.append(f"啟動 Started: {started_short}")
+        if session_parts:
+            lines.append(" · ".join(session_parts))
+
+        lines.extend([
             f"策略: {strategy.get('name', '?')}",
             f"交易: {total} 筆 | 勝率: {win_rate:.1%} | PF: {pf:.2f}",
             f"損益: {pnl:+,} | 最大回撤: {dd:,}",
-        ]
+        ])
         if regime:
             lines.append(
                 f"市場狀態: {regime.get('label', '?')} "

--- a/src/live/discord_notify.py
+++ b/src/live/discord_notify.py
@@ -125,3 +125,30 @@ class DiscordNotifier:
             f"🚫 **每日虧損上限 Daily Loss Limit**\n"
             f"淨損益: {net_pnl:+,} | 上限: -{limit:,}"
         )
+
+    def daily_report(self, report: dict) -> None:
+        """Send a daily report summary to Discord."""
+        date = report.get("date", "?")
+        summary = report.get("summary", {})
+        regime = report.get("market_regime")
+        strategy = report.get("strategy", {})
+
+        total = summary.get("total_trades", 0)
+        pnl = summary.get("total_pnl", 0)
+        win_rate = summary.get("win_rate", 0)
+        pf = summary.get("profit_factor", 0)
+        dd = summary.get("max_drawdown", 0)
+
+        lines = [
+            f"{self._header()}",
+            f"📊 **每日報告 Daily Report** — {date}",
+            f"策略: {strategy.get('name', '?')}",
+            f"交易: {total} 筆 | 勝率: {win_rate:.1%} | PF: {pf:.2f}",
+            f"損益: {pnl:+,} | 最大回撤: {dd:,}",
+        ]
+        if regime:
+            lines.append(
+                f"市場狀態: {regime.get('label', '?')} "
+                f"(ADX {regime.get('adx', 0):.1f})"
+            )
+        self._send("\n".join(lines))

--- a/src/live/live_runner.py
+++ b/src/live/live_runner.py
@@ -260,6 +260,13 @@ class LiveRunner:
         self.trading_mode: str = "paper"  # "paper", "semi_auto", or "auto"
         self.daily_loss_limit: int = 10000  # NTD, for session persistence
 
+        # Daily-report dedupe key: (date_str, "DAY"|"NIGHT") of the last
+        # session for which a report was emitted. Prevents the 30s
+        # session-end poll from re-firing within the same close window
+        # and prevents a manual stop right after auto-fire from
+        # producing a duplicate report.
+        self._last_report_session: tuple[str, str] | None = None
+
     # ── Lock file ──
 
     def acquire_lock(self) -> None:
@@ -796,9 +803,34 @@ class LiveRunner:
         except Exception:
             pass  # best-effort; don't crash the bot
 
+    def _session_key(self) -> tuple[str, str]:
+        """Return ``(YYYY-MM-DD, "DAY"|"NIGHT")`` for the current TPE moment.
+
+        DAY covers 08:45 ≤ hh:mm < 13:46 — one extra minute past the
+        13:45 close so a poll at 13:45:30 still classifies as DAY.
+        Everything else is NIGHT — the night session straddles midnight
+        (15:00–05:00 TPE), so "not DAY" is the correct partition.
+        """
+        now = _taipei_now()
+        minutes = now.hour * 60 + now.minute
+        # 525 = 08:45, 826 = 13:46 (one minute past day-session close).
+        slot = "DAY" if 525 <= minutes < 826 else "NIGHT"
+        return (now.strftime("%Y-%m-%d"), slot)
+
     def _generate_daily_report(self) -> None:
-        """Generate a daily report after session stop (best-effort)."""
+        """Generate a daily report after session stop (best-effort).
+
+        Debounced per ``(date, DAY|NIGHT)`` so that the same session is
+        never reported twice — the 30s session-end poll fires this
+        method repeatedly inside the close window, and a manual stop
+        right after auto-fire would otherwise produce a duplicate.
+        """
         try:
+            key = self._session_key()
+            if key == self._last_report_session:
+                return
+            self._last_report_session = key
+
             from ..daily_report.report_generator import generate_session_report
             report = generate_session_report(
                 broker=self.broker,

--- a/src/live/live_runner.py
+++ b/src/live/live_runner.py
@@ -757,6 +757,7 @@ class LiveRunner:
             )
 
         self._auto_save_session()
+        self._generate_daily_report()
         self.csv_logger.close()
         self.release_lock()
         self.state = LiveState.STOPPED
@@ -794,6 +795,23 @@ class LiveRunner:
             save_session(self._session_path, data)
         except Exception:
             pass  # best-effort; don't crash the bot
+
+    def _generate_daily_report(self) -> None:
+        """Generate a daily report after session stop (best-effort)."""
+        try:
+            from ..daily_report.report_generator import generate_session_report
+            report = generate_session_report(
+                broker=self.broker,
+                data_store=self.data_store,
+                strategy_name=self.strategy_display_name,
+                strategy_params=getattr(self.strategy, "params", None),
+                point_value=self.point_value,
+                symbol=self.symbol,
+            )
+            if report is not None:
+                self._emit("on_daily_report", report)
+        except Exception:
+            pass  # best-effort; don't crash the bot on report failure
 
     def restore_session(self, session_data: dict) -> int:
         """Restore broker state from a saved session.

--- a/src/live/live_runner.py
+++ b/src/live/live_runner.py
@@ -839,6 +839,8 @@ class LiveRunner:
                 strategy_params=getattr(self.strategy, "params", None),
                 point_value=self.point_value,
                 symbol=self.symbol,
+                bot_name=self.bot_name,
+                started_at=self._started_at,
             )
             if report is not None:
                 self._emit("on_daily_report", report)

--- a/tests/test_daily_report.py
+++ b/tests/test_daily_report.py
@@ -527,6 +527,55 @@ class TestDiscordDailyReport:
         assert "SMA Cross" in msg
         assert "trending-up" in msg
 
+    def test_daily_report_includes_session_line(self):
+        from src.live.discord_notify import DiscordNotifier
+
+        notifier = DiscordNotifier("fake-token", "fake-channel")
+        sent = []
+        notifier._send = lambda msg: sent.append(msg)
+
+        report = {
+            "date": "2026-04-11",
+            "summary": {"total_trades": 1, "total_pnl": 100,
+                        "win_rate": 1.0, "profit_factor": 0,
+                        "max_drawdown": 0},
+            "strategy": {"name": "Test"},
+            "market_regime": None,
+            "session": {
+                "bot_name": "tmf00_main",
+                "started_at": "2026-04-11T08:45:00",
+                "version": "2.7.3",
+            },
+        }
+        notifier.daily_report(report)
+
+        assert len(sent) == 1
+        msg = sent[0]
+        assert "tmf00_main" in msg
+        assert "v2.7.3" in msg
+        # Started timestamp trimmed to minute precision (no seconds, no T)
+        assert "2026-04-11 08:45" in msg
+        assert "2026-04-11T08:45:00" not in msg
+
+    def test_daily_report_without_session_field(self):
+        """Reports without a session sub-dict (older saves) still render."""
+        from src.live.discord_notify import DiscordNotifier
+
+        notifier = DiscordNotifier("fake-token", "fake-channel")
+        sent = []
+        notifier._send = lambda msg: sent.append(msg)
+
+        report = {
+            "date": "2026-04-11",
+            "summary": {"total_trades": 0, "total_pnl": 0,
+                        "win_rate": 0, "profit_factor": 0,
+                        "max_drawdown": 0},
+            "strategy": {"name": "Test"},
+            "market_regime": None,
+        }
+        notifier.daily_report(report)
+        assert len(sent) == 1  # didn't crash
+
     def test_daily_report_without_regime(self):
         from src.live.discord_notify import DiscordNotifier
 
@@ -679,6 +728,26 @@ class TestGenerateSessionReport:
 
         broker = _FakeBroker([])
         assert generate_session_report(broker=broker, data_store=None) is None
+
+    def test_session_metadata_propagates(self, tmp_path, monkeypatch):
+        import src.daily_report.report_generator as rg
+        monkeypatch.setattr(rg, "_REPORTS_DIR", tmp_path)
+
+        trades = [_make_trade(exit_dt="2026-04-11 10:30")]
+        broker = _FakeBroker(trades)
+
+        report = generate_session_report(
+            broker=broker,
+            data_store=None,
+            symbol="TXF1",
+            bot_name="tmf00_main",
+            started_at="2026-04-11T08:45:00",
+        )
+        assert report is not None
+        assert report["session"]["bot_name"] == "tmf00_main"
+        assert report["session"]["started_at"] == "2026-04-11T08:45:00"
+        # version comes from version.APP_VERSION
+        assert report["session"]["version"]  # non-empty
 
     def test_explicit_date(self, tmp_path, monkeypatch):
         import src.daily_report.report_generator as rg

--- a/tests/test_daily_report.py
+++ b/tests/test_daily_report.py
@@ -21,6 +21,7 @@ from src.daily_report.regime_classifier import (
 from src.daily_report.report_generator import (
     generate_daily_report,
     generate_report_from_backtest,
+    generate_session_report,
     load_report,
     list_reports,
     _group_trades_by_date,
@@ -545,3 +546,182 @@ class TestDiscordDailyReport:
 
         assert len(sent) == 1
         assert "trending" not in sent[0]  # no regime line
+
+
+# ---------------------------------------------------------------------------
+# Graceful field handling tests
+# ---------------------------------------------------------------------------
+
+class TestGracefulFieldHandling:
+    """Ensure _trade_to_dict handles missing/partial fields from any strategy."""
+
+    def test_standard_trade(self, tmp_path, monkeypatch):
+        import src.daily_report.report_generator as rg
+        monkeypatch.setattr(rg, "_REPORTS_DIR", tmp_path)
+
+        report = generate_daily_report(
+            date="2026-04-11",
+            trades=[_make_trade()],
+            save=False,
+        )
+        td = report["trades"][0]
+        assert td["side"] == "LONG"
+        assert td["tag"] == "Long"
+
+    def test_trade_with_zero_pnl(self, tmp_path, monkeypatch):
+        import src.daily_report.report_generator as rg
+        monkeypatch.setattr(rg, "_REPORTS_DIR", tmp_path)
+
+        t = _make_trade(pnl=0, entry_price=20000, exit_price=20000)
+        report = generate_daily_report(
+            date="2026-04-11", trades=[t], point_value=200, save=False,
+        )
+        td = report["trades"][0]
+        assert td["pnl"] == 0
+        assert td["pnl_currency"] == 0
+
+    def test_trade_with_no_real_prices(self, tmp_path, monkeypatch):
+        import src.daily_report.report_generator as rg
+        monkeypatch.setattr(rg, "_REPORTS_DIR", tmp_path)
+
+        t = _make_trade()
+        assert t.real_entry_price == 0  # default
+        report = generate_daily_report(
+            date="2026-04-11", trades=[t], save=False,
+        )
+        td = report["trades"][0]
+        assert td["real_entry_price"] is None
+        assert td["real_exit_price"] is None
+
+    def test_short_side_trade(self, tmp_path, monkeypatch):
+        import src.daily_report.report_generator as rg
+        monkeypatch.setattr(rg, "_REPORTS_DIR", tmp_path)
+
+        t = _make_trade(side=OrderSide.SHORT, tag="Short")
+        report = generate_daily_report(
+            date="2026-04-11", trades=[t], save=False,
+        )
+        assert report["trades"][0]["side"] == "SHORT"
+
+
+# ---------------------------------------------------------------------------
+# generate_session_report tests
+# ---------------------------------------------------------------------------
+
+class _FakeBroker:
+    """Minimal broker-like object for testing generate_session_report."""
+    def __init__(self, trades):
+        self.trades = trades
+
+
+class _FakeDataStore:
+    """Minimal data-store-like object with get_highs/lows/closes."""
+    def __init__(self, highs, lows, closes):
+        self._highs = highs
+        self._lows = lows
+        self._closes = closes
+
+    def get_highs(self):
+        return self._highs
+
+    def get_lows(self):
+        return self._lows
+
+    def get_closes(self):
+        return self._closes
+
+
+class TestGenerateSessionReport:
+    def test_basic_session_report(self, tmp_path, monkeypatch):
+        import src.daily_report.report_generator as rg
+        monkeypatch.setattr(rg, "_REPORTS_DIR", tmp_path)
+
+        trades = [
+            _make_trade(pnl=100, exit_dt="2026-04-11 10:30"),
+            _make_trade(pnl=-30, exit_dt="2026-04-11 13:00"),
+        ]
+        broker = _FakeBroker(trades)
+
+        report = generate_session_report(
+            broker=broker,
+            data_store=None,
+            strategy_name="Test Strategy",
+            point_value=200,
+            symbol="TXF1",
+        )
+        assert report is not None
+        assert report["date"] == "2026-04-11"
+        assert report["symbol"] == "TXF1"
+        assert len(report["trades"]) == 2
+        assert report["market_regime"] is None  # no data store
+
+    def test_session_report_with_data_store(self, tmp_path, monkeypatch):
+        import src.daily_report.report_generator as rg
+        monkeypatch.setattr(rg, "_REPORTS_DIR", tmp_path)
+
+        trades = [_make_trade(exit_dt="2026-04-11 10:30")]
+        broker = _FakeBroker(trades)
+        highs, lows, closes = _trending_up_bars(120)
+        ds = _FakeDataStore(highs, lows, closes)
+
+        report = generate_session_report(
+            broker=broker,
+            data_store=ds,
+            strategy_name="Trend Follower",
+            symbol="TXF1",
+        )
+        assert report is not None
+        assert report["market_regime"] is not None
+
+    def test_no_trades_returns_none(self, tmp_path, monkeypatch):
+        import src.daily_report.report_generator as rg
+        monkeypatch.setattr(rg, "_REPORTS_DIR", tmp_path)
+
+        broker = _FakeBroker([])
+        assert generate_session_report(broker=broker, data_store=None) is None
+
+    def test_explicit_date(self, tmp_path, monkeypatch):
+        import src.daily_report.report_generator as rg
+        monkeypatch.setattr(rg, "_REPORTS_DIR", tmp_path)
+
+        trades = [_make_trade(exit_dt="2026-04-11 10:30")]
+        broker = _FakeBroker(trades)
+
+        report = generate_session_report(
+            broker=broker, data_store=None, date="2026-04-10",
+        )
+        assert report is not None
+        # Explicit date overrides trade exit date
+        assert report["date"] == "2026-04-10"
+
+    def test_saves_to_disk(self, tmp_path, monkeypatch):
+        import src.daily_report.report_generator as rg
+        monkeypatch.setattr(rg, "_REPORTS_DIR", tmp_path)
+
+        trades = [_make_trade(exit_dt="2026-04-11 10:30")]
+        broker = _FakeBroker(trades)
+
+        generate_session_report(broker=broker, data_store=None)
+        assert (tmp_path / "2026-04-11.json").exists()
+
+    def test_data_store_error_handled(self, tmp_path, monkeypatch):
+        """If data_store.get_highs() raises, regime is skipped (not crash)."""
+        import src.daily_report.report_generator as rg
+        monkeypatch.setattr(rg, "_REPORTS_DIR", tmp_path)
+
+        class _BrokenDataStore:
+            def get_highs(self):
+                raise RuntimeError("broken")
+            def get_lows(self):
+                return []
+            def get_closes(self):
+                return []
+
+        trades = [_make_trade(exit_dt="2026-04-11 10:30")]
+        broker = _FakeBroker(trades)
+
+        report = generate_session_report(
+            broker=broker, data_store=_BrokenDataStore(),
+        )
+        assert report is not None
+        assert report["market_regime"] is None

--- a/tests/test_daily_report.py
+++ b/tests/test_daily_report.py
@@ -1,0 +1,547 @@
+"""Tests for daily report pipeline: regime classifier, report generator, changelog."""
+
+from __future__ import annotations
+
+import json
+import math
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from src.backtest.broker import Trade, OrderSide
+from src.daily_report.regime_classifier import (
+    classify_regime,
+    RegimeResult,
+    _classify_trend,
+    _classify_volatility,
+    _classify_direction,
+    _combine_label,
+)
+from src.daily_report.report_generator import (
+    generate_daily_report,
+    generate_report_from_backtest,
+    load_report,
+    list_reports,
+    _group_trades_by_date,
+)
+from src.daily_report.changelog import (
+    append_changelog,
+    load_changelog,
+    recent_changes,
+    _CHANGELOG_PATH,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_trade(
+    pnl: int = 100,
+    side: OrderSide = OrderSide.LONG,
+    entry_price: int = 20000,
+    exit_price: int = 20100,
+    entry_dt: str = "2026-04-11 09:00",
+    exit_dt: str = "2026-04-11 10:30",
+    entry_bar: int = 0,
+    exit_bar: int = 5,
+    tag: str = "Long",
+    exit_tag: str = "limit",
+) -> Trade:
+    return Trade(
+        tag=tag,
+        side=side,
+        qty=1,
+        entry_price=entry_price,
+        exit_price=exit_price,
+        entry_bar_index=entry_bar,
+        exit_bar_index=exit_bar,
+        pnl=pnl,
+        exit_tag=exit_tag,
+        entry_dt=entry_dt,
+        exit_dt=exit_dt,
+    )
+
+
+def _trending_up_bars(n: int = 80) -> tuple[list[int], list[int], list[int]]:
+    """Generate synthetic uptrending bars with clear directional movement."""
+    highs, lows, closes = [], [], []
+    base = 20000
+    for i in range(n):
+        h = base + i * 30 + 50
+        l = base + i * 30 - 10
+        c = base + i * 30 + 20
+        highs.append(h)
+        lows.append(l)
+        closes.append(c)
+    return highs, lows, closes
+
+
+def _range_bound_bars(n: int = 80) -> tuple[list[int], list[int], list[int]]:
+    """Generate synthetic range-bound bars oscillating around a center."""
+    import math as _math
+    highs, lows, closes = [], [], []
+    center = 20000
+    for i in range(n):
+        offset = int(50 * _math.sin(i * 0.5))
+        h = center + offset + 30
+        l = center + offset - 30
+        c = center + offset
+        highs.append(h)
+        lows.append(l)
+        closes.append(c)
+    return highs, lows, closes
+
+
+# ---------------------------------------------------------------------------
+# Regime classifier tests
+# ---------------------------------------------------------------------------
+
+class TestClassifyTrend:
+    def test_trending(self):
+        assert _classify_trend(30.0) == "trending"
+        assert _classify_trend(25.1) == "trending"
+
+    def test_range_bound(self):
+        assert _classify_trend(15.0) == "range-bound"
+        assert _classify_trend(19.9) == "range-bound"
+
+    def test_transitional(self):
+        assert _classify_trend(20.0) == "transitional"
+        assert _classify_trend(22.5) == "transitional"
+        assert _classify_trend(25.0) == "transitional"
+
+
+class TestClassifyVolatility:
+    def test_high(self):
+        assert _classify_volatility(1.5) == "high"
+        assert _classify_volatility(1.31) == "high"
+
+    def test_low(self):
+        assert _classify_volatility(0.5) == "low"
+        assert _classify_volatility(0.69) == "low"
+
+    def test_normal(self):
+        assert _classify_volatility(1.0) == "normal"
+        assert _classify_volatility(0.7) == "normal"
+        assert _classify_volatility(1.3) == "normal"
+
+
+class TestClassifyDirection:
+    def test_bullish_above_ema(self):
+        assert _classify_direction(20100, 20000) == "bullish"
+
+    def test_bearish_below_ema(self):
+        assert _classify_direction(19900, 20000) == "bearish"
+
+    def test_equal_is_bullish(self):
+        assert _classify_direction(20000, 20000) == "bullish"
+
+
+class TestCombineLabel:
+    def test_trending_up(self):
+        assert _combine_label("trending", "normal", "bullish") == "trending-up"
+
+    def test_trending_down(self):
+        assert _combine_label("trending", "normal", "bearish") == "trending-down"
+
+    def test_range_bound(self):
+        assert _combine_label("range-bound", "normal", "bullish") == "range-bound"
+
+    def test_high_volatility_overrides(self):
+        assert _combine_label("trending", "high", "bullish") == "high-volatility"
+        assert _combine_label("range-bound", "high", "bearish") == "high-volatility"
+
+    def test_low_volatility_chop(self):
+        assert _combine_label("range-bound", "low", "bearish") == "low-volatility-chop"
+
+    def test_transitional(self):
+        assert _combine_label("transitional", "normal", "bullish") == "transitional-bullish"
+        assert _combine_label("transitional", "normal", "bearish") == "transitional-bearish"
+
+
+class TestClassifyRegime:
+    def test_insufficient_data_returns_none(self):
+        result = classify_regime([1, 2, 3], [1, 2, 3], [1, 2, 3])
+        assert result is None
+
+    def test_trending_up_data(self):
+        highs, lows, closes = _trending_up_bars(120)
+        result = classify_regime(highs, lows, closes)
+        assert result is not None
+        assert isinstance(result, RegimeResult)
+        assert result.direction == "bullish"
+        # With strong trend data, ADX should be elevated
+        assert result.adx_value > 0
+        assert result.ema_50 > 0
+        assert result.atr_value > 0
+
+    def test_to_dict_keys(self):
+        highs, lows, closes = _trending_up_bars(120)
+        result = classify_regime(highs, lows, closes)
+        assert result is not None
+        d = result.to_dict()
+        expected_keys = {
+            "label", "trend_strength", "volatility", "direction",
+            "adx", "plus_di", "minus_di", "atr", "atr_ratio",
+            "ema_50", "last_close",
+        }
+        assert set(d.keys()) == expected_keys
+
+    def test_range_bound_data(self):
+        highs, lows, closes = _range_bound_bars(120)
+        result = classify_regime(highs, lows, closes)
+        assert result is not None
+        # Range-bound data should have lower ADX
+        # (not guaranteed to be < 20 with synthetic data, but should exist)
+        assert result.adx_value >= 0
+
+    def test_custom_periods(self):
+        highs, lows, closes = _trending_up_bars(200)
+        result = classify_regime(
+            highs, lows, closes,
+            adx_period=20, atr_period=20, ema_period=100,
+        )
+        # With 200 bars and period=20/100, should still work
+        assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# Report generator tests
+# ---------------------------------------------------------------------------
+
+class TestGroupTradesByDate:
+    def test_single_day(self):
+        trades = [
+            _make_trade(exit_dt="2026-04-11 10:30"),
+            _make_trade(exit_dt="2026-04-11 13:00"),
+        ]
+        grouped = _group_trades_by_date(trades)
+        assert list(grouped.keys()) == ["2026-04-11"]
+        assert len(grouped["2026-04-11"]) == 2
+
+    def test_multiple_days(self):
+        trades = [
+            _make_trade(exit_dt="2026-04-10 10:30"),
+            _make_trade(exit_dt="2026-04-11 13:00"),
+            _make_trade(exit_dt="2026-04-11 14:00"),
+        ]
+        grouped = _group_trades_by_date(trades)
+        assert len(grouped) == 2
+        assert len(grouped["2026-04-10"]) == 1
+        assert len(grouped["2026-04-11"]) == 2
+
+    def test_skips_trades_without_exit_dt(self):
+        trades = [
+            _make_trade(exit_dt="2026-04-11 10:30"),
+            _make_trade(exit_dt=""),
+        ]
+        grouped = _group_trades_by_date(trades)
+        assert len(grouped["2026-04-11"]) == 1
+
+
+class TestGenerateDailyReport:
+    def test_basic_report_structure(self, tmp_path, monkeypatch):
+        import src.daily_report.report_generator as rg
+        monkeypatch.setattr(rg, "_REPORTS_DIR", tmp_path)
+
+        trades = [
+            _make_trade(pnl=200, exit_dt="2026-04-11 10:30"),
+            _make_trade(pnl=-50, exit_dt="2026-04-11 13:00"),
+        ]
+
+        report = generate_daily_report(
+            date="2026-04-11",
+            trades=trades,
+            strategy_name="Test Strategy",
+            strategy_version="1.0",
+            strategy_params={"fast": 3, "slow": 8},
+            point_value=200,
+            symbol="TXF1",
+            save=True,
+        )
+
+        assert report["date"] == "2026-04-11"
+        assert report["symbol"] == "TXF1"
+        assert report["strategy"]["name"] == "Test Strategy"
+        assert report["strategy"]["version"] == "1.0"
+        assert report["strategy"]["params"] == {"fast": 3, "slow": 8}
+        assert len(report["trades"]) == 2
+        assert report["summary"]["total_trades"] == 2
+        assert report["summary"]["total_pnl"] == 150  # 200 + (-50)
+        assert report["summary"]["winning_trades"] == 1
+        assert report["summary"]["losing_trades"] == 1
+
+        # Check file was written
+        saved = tmp_path / "2026-04-11.json"
+        assert saved.exists()
+        loaded = json.loads(saved.read_text())
+        assert loaded["date"] == "2026-04-11"
+
+    def test_no_save(self, tmp_path, monkeypatch):
+        import src.daily_report.report_generator as rg
+        monkeypatch.setattr(rg, "_REPORTS_DIR", tmp_path)
+
+        report = generate_daily_report(
+            date="2026-04-11",
+            trades=[_make_trade()],
+            save=False,
+        )
+        assert report["date"] == "2026-04-11"
+        assert not (tmp_path / "2026-04-11.json").exists()
+
+    def test_with_regime_data(self, tmp_path, monkeypatch):
+        import src.daily_report.report_generator as rg
+        monkeypatch.setattr(rg, "_REPORTS_DIR", tmp_path)
+
+        highs, lows, closes = _trending_up_bars(120)
+        report = generate_daily_report(
+            date="2026-04-11",
+            trades=[_make_trade()],
+            bars_highs=highs,
+            bars_lows=lows,
+            bars_closes=closes,
+            save=False,
+        )
+        assert report["market_regime"] is not None
+        assert "label" in report["market_regime"]
+        assert "adx" in report["market_regime"]
+
+    def test_empty_trades(self, tmp_path, monkeypatch):
+        import src.daily_report.report_generator as rg
+        monkeypatch.setattr(rg, "_REPORTS_DIR", tmp_path)
+
+        report = generate_daily_report(
+            date="2026-04-11", trades=[], save=False,
+        )
+        assert report["summary"]["total_trades"] == 0
+        assert report["trades"] == []
+
+    def test_trade_dict_fields(self, tmp_path, monkeypatch):
+        import src.daily_report.report_generator as rg
+        monkeypatch.setattr(rg, "_REPORTS_DIR", tmp_path)
+
+        report = generate_daily_report(
+            date="2026-04-11",
+            trades=[_make_trade(pnl=100, entry_bar=2, exit_bar=7)],
+            point_value=200,
+            save=False,
+        )
+        td = report["trades"][0]
+        assert td["pnl"] == 100
+        assert td["pnl_currency"] == 20000  # 100 * 200
+        assert td["bars_held"] == 5
+        assert td["side"] == "LONG"
+        assert td["exit_tag"] == "limit"
+
+
+class TestGenerateReportFromBacktest:
+    def test_splits_by_date(self, tmp_path, monkeypatch):
+        import src.daily_report.report_generator as rg
+        monkeypatch.setattr(rg, "_REPORTS_DIR", tmp_path)
+
+        trades = [
+            _make_trade(pnl=100, exit_dt="2026-04-10 10:00"),
+            _make_trade(pnl=200, exit_dt="2026-04-11 10:00"),
+            _make_trade(pnl=-50, exit_dt="2026-04-11 14:00"),
+        ]
+        equity = [100, 300, 250]
+
+        reports = generate_report_from_backtest(
+            trades=trades,
+            equity_curve=equity,
+            strategy_name="BT Strategy",
+            save=True,
+        )
+
+        assert len(reports) == 2
+        assert reports[0]["date"] == "2026-04-10"
+        assert reports[1]["date"] == "2026-04-11"
+        assert len(reports[1]["trades"]) == 2
+
+        # Both files saved
+        assert (tmp_path / "2026-04-10.json").exists()
+        assert (tmp_path / "2026-04-11.json").exists()
+
+
+class TestLoadAndListReports:
+    def test_load_existing(self, tmp_path, monkeypatch):
+        import src.daily_report.report_generator as rg
+        monkeypatch.setattr(rg, "_REPORTS_DIR", tmp_path)
+
+        data = {"date": "2026-04-11", "test": True}
+        (tmp_path / "2026-04-11.json").write_text(json.dumps(data))
+
+        loaded = load_report("2026-04-11")
+        assert loaded == data
+
+    def test_load_missing(self, tmp_path, monkeypatch):
+        import src.daily_report.report_generator as rg
+        monkeypatch.setattr(rg, "_REPORTS_DIR", tmp_path)
+
+        assert load_report("2099-01-01") is None
+
+    def test_list_reports(self, tmp_path, monkeypatch):
+        import src.daily_report.report_generator as rg
+        monkeypatch.setattr(rg, "_REPORTS_DIR", tmp_path)
+
+        (tmp_path / "2026-04-10.json").write_text("{}")
+        (tmp_path / "2026-04-11.json").write_text("{}")
+
+        dates = list_reports()
+        assert dates == ["2026-04-10", "2026-04-11"]
+
+    def test_list_empty(self, tmp_path, monkeypatch):
+        import src.daily_report.report_generator as rg
+        monkeypatch.setattr(rg, "_REPORTS_DIR", tmp_path)
+
+        assert list_reports() == []
+
+
+# ---------------------------------------------------------------------------
+# Changelog tests
+# ---------------------------------------------------------------------------
+
+class TestChangelog:
+    def test_append_and_load(self, tmp_path, monkeypatch):
+        import src.daily_report.changelog as cl
+        monkeypatch.setattr(cl, "_CHANGELOG_PATH", tmp_path / "changelog.json")
+
+        entry = append_changelog(
+            strategy_name="SMA Cross",
+            version_before="1.0",
+            version_after="1.1",
+            change_summary="Increased fast SMA from 3 to 5",
+            initiated_by="human",
+            params_before={"fast": 3},
+            params_after={"fast": 5},
+        )
+        assert entry["strategy"] == "SMA Cross"
+        assert entry["version_before"] == "1.0"
+        assert entry["version_after"] == "1.1"
+        assert entry["initiated_by"] == "human"
+
+        entries = load_changelog()
+        assert len(entries) == 1
+        assert entries[0]["change_summary"] == "Increased fast SMA from 3 to 5"
+
+    def test_multiple_entries(self, tmp_path, monkeypatch):
+        import src.daily_report.changelog as cl
+        monkeypatch.setattr(cl, "_CHANGELOG_PATH", tmp_path / "changelog.json")
+
+        for i in range(5):
+            append_changelog(
+                strategy_name="Test",
+                version_before=f"{i}.0",
+                version_after=f"{i + 1}.0",
+                change_summary=f"Change {i}",
+            )
+
+        entries = load_changelog()
+        assert len(entries) == 5
+
+    def test_recent_changes(self, tmp_path, monkeypatch):
+        import src.daily_report.changelog as cl
+        monkeypatch.setattr(cl, "_CHANGELOG_PATH", tmp_path / "changelog.json")
+
+        for i in range(5):
+            append_changelog(
+                strategy_name="Test",
+                version_before=f"{i}.0",
+                version_after=f"{i + 1}.0",
+                change_summary=f"Change {i}",
+            )
+
+        recent = recent_changes(n=3)
+        assert len(recent) == 3
+        # Newest first
+        assert recent[0]["change_summary"] == "Change 4"
+        assert recent[2]["change_summary"] == "Change 2"
+
+    def test_empty_changelog(self, tmp_path, monkeypatch):
+        import src.daily_report.changelog as cl
+        monkeypatch.setattr(cl, "_CHANGELOG_PATH", tmp_path / "changelog.json")
+
+        assert load_changelog() == []
+        assert recent_changes() == []
+
+    def test_corrupt_file_returns_empty(self, tmp_path, monkeypatch):
+        import src.daily_report.changelog as cl
+        path = tmp_path / "changelog.json"
+        monkeypatch.setattr(cl, "_CHANGELOG_PATH", path)
+
+        path.write_text("not valid json{{{")
+        assert load_changelog() == []
+
+    def test_with_metrics(self, tmp_path, monkeypatch):
+        import src.daily_report.changelog as cl
+        monkeypatch.setattr(cl, "_CHANGELOG_PATH", tmp_path / "changelog.json")
+
+        entry = append_changelog(
+            strategy_name="BB Strategy",
+            version_before="2.0",
+            version_after="2.1",
+            change_summary="Tightened stop",
+            initiated_by="ai",
+            metrics_before={"win_rate": 0.45, "profit_factor": 1.2},
+            metrics_after={"win_rate": 0.50, "profit_factor": 1.5},
+        )
+        assert entry["metrics_before"]["win_rate"] == 0.45
+        assert entry["metrics_after"]["profit_factor"] == 1.5
+        assert entry["initiated_by"] == "ai"
+
+
+# ---------------------------------------------------------------------------
+# Discord notifier daily_report method
+# ---------------------------------------------------------------------------
+
+class TestDiscordDailyReport:
+    def test_daily_report_formats_message(self):
+        from src.live.discord_notify import DiscordNotifier
+
+        notifier = DiscordNotifier("fake-token", "fake-channel")
+        # Patch _send to capture the message
+        sent = []
+        notifier._send = lambda msg: sent.append(msg)
+
+        report = {
+            "date": "2026-04-11",
+            "summary": {
+                "total_trades": 5,
+                "total_pnl": 1500,
+                "win_rate": 0.6,
+                "profit_factor": 2.5,
+                "max_drawdown": 300,
+            },
+            "strategy": {"name": "SMA Cross"},
+            "market_regime": {"label": "trending-up", "adx": 32.5},
+        }
+        notifier.daily_report(report)
+
+        assert len(sent) == 1
+        msg = sent[0]
+        assert "Daily Report" in msg
+        assert "2026-04-11" in msg
+        assert "SMA Cross" in msg
+        assert "trending-up" in msg
+
+    def test_daily_report_without_regime(self):
+        from src.live.discord_notify import DiscordNotifier
+
+        notifier = DiscordNotifier("fake-token", "fake-channel")
+        sent = []
+        notifier._send = lambda msg: sent.append(msg)
+
+        report = {
+            "date": "2026-04-11",
+            "summary": {"total_trades": 0, "total_pnl": 0,
+                        "win_rate": 0, "profit_factor": 0,
+                        "max_drawdown": 0},
+            "strategy": {"name": "Test"},
+            "market_regime": None,
+        }
+        notifier.daily_report(report)
+
+        assert len(sent) == 1
+        assert "trending" not in sent[0]  # no regime line


### PR DESCRIPTION
## Summary

Phase A of the automated strategy refinement system. This adds the foundational data pipeline that future phases (walk-forward validation, AI diagnosis) will build on.

### What's included

**1. Market Regime Classifier** (`src/daily_report/regime_classifier.py`)
- Uses existing ADX (14-period) for trend strength: >25 trending, <20 range-bound, 20-25 transitional
- ATR ratio (current / 20-bar average) for volatility: >1.3 high, <0.7 low
- Price vs 50-EMA for directional bias
- Combines into regime labels: `trending-up`, `trending-down`, `range-bound`, `high-volatility`, `low-volatility-chop`, `transitional-bullish/bearish`
- All raw indicator values (ADX, +DI, -DI, ATR, ATR ratio, EMA) included in output for downstream AI analysis
- Reuses existing `adx()`, `atr()`, `ema()` from `src/strategy/indicators/`

**2. Daily Report Generator** (`src/daily_report/report_generator.py`)
- Generates structured JSON reports per trading day
- Per-trade details: entry/exit time, direction, prices, P&L (raw + currency), bars held, exit trigger
- Daily summary: reuses `calculate_metrics()` from `src/backtest/metrics.py` — total P&L, win rate, profit factor, max drawdown, Sharpe, avg bars held
- Strategy metadata: name, version, current parameters
- Market regime context from the classifier
- `generate_report_from_backtest()` splits a full backtest into per-day reports
- Stored in `data/daily-reports/YYYY-MM-DD.json` (gitignored `data/` directory)
- `load_report()` and `list_reports()` for querying saved reports

**3. Strategy Changelog** (`src/daily_report/changelog.py`)
- `data/changelog.json` — append-only array of change entries
- Each entry: date, strategy name, version before/after, change summary, who initiated (human/AI), metrics before/after, params before/after
- `append_changelog()`, `load_changelog()`, `recent_changes(n)` helper functions

**4. CLI Entry Point** (`src/daily_report/__main__.py`)
- `python -m src.daily_report --date 2026-04-11 --show` — view a saved report
- `python -m src.daily_report --list` — list all available report dates

**5. Discord Integration** (`src/live/discord_notify.py`)
- New `daily_report(report)` method sends a summary to Discord
- Shows date, strategy name, trade count, win rate, PF, P&L, max drawdown, and regime label

**6. Version bump**: 2.5.9 → 2.6.0

## Design decisions

- **Reuses existing code**: metrics calculation, all indicators, Trade dataclass, Discord notifier pattern
- **No new dependencies**: pure Python, uses existing `json`/`pathlib`/`dataclasses`
- **Importable + CLI**: report generator is both a library (for Phase B walk-forward validator) and a CLI tool
- **Monkeypatch-friendly**: file paths are module-level constants, easily overridden in tests

## Test plan

- [x] 41 new tests covering all components (regime classifier, report generator, changelog, Discord)
- [x] Full test suite passes: 804 passed, 5 skipped
- [x] Regime classifier tested with synthetic trending and range-bound data
- [x] Report generator tested with edge cases (empty trades, no save, with/without regime data)
- [x] Changelog tested for append, load, recent queries, corrupt file handling
- [x] Discord method tested for message formatting with and without regime data

🤖 Generated with [Claude Code](https://claude.com/claude-code)