### PR TITLE
Hotfix: Force-close direction bug (insufficient margin error)

### DIFF
--- a/run_backtest.py
+++ b/run_backtest.py
@@ -3749,7 +3749,7 @@ class BacktestApp:
             return
         last_bar = bars[-1]
         last_dt = last_bar.dt.strftime("%Y-%m-%d %H:%M") if last_bar.dt else ""
-        side = runner.broker.trades[-1].side.value if runner.broker.trades else ""
+        side = runner.broker.position_side.value if runner.broker.position_side else ""
 
         self._live_log_msg(
             f"盤前自動平倉 Session-end auto close: {mins}min to close, "
@@ -4077,8 +4077,13 @@ class BacktestApp:
             self._live_log_msg(
                 f"{label}自動送單 Auto-sending {action.lower()}: {order_desc} {order_symbol}", "exit")
             self._log_order_decision("REAL_ORDER_AUTO", f"{action.lower()} {order_desc} {order_symbol}")
-            self._send_real_order(buy_sell, order_symbol, action_type, price,
-                                 new_close=new_close, exit_type=exit_type, exit_limit=exit_limit)
+            ok = self._send_real_order(buy_sell, order_symbol, action_type, price,
+                                       new_close=new_close, exit_type=exit_type, exit_limit=exit_limit)
+            # Force-close failure: schedule retries with escalating delays
+            if not ok and action == "FORCE_CLOSE":
+                self._retry_force_close(
+                    buy_sell, order_symbol, price,
+                    attempt=1, max_attempts=3, last_error="initial send failed")
             # State transition deferred to _on_fill_confirmed (auto) or
             # handled inside _send_real_order (semi_auto)
             return
@@ -4194,6 +4199,8 @@ class BacktestApp:
             pass  # logged in _send_real_order
         # "replaced" = new dialog replaced old one, no log needed
 
+    _FORCE_CLOSE_RETRY_DELAYS = [5000, 10000, 15000]  # ms
+
     def _send_real_order(self, buy_sell, order_symbol, action_type, sim_price,
                          new_close=2, exit_type="", exit_limit=None):
         """Build FUTUREORDER and send via COM SKOrderLib.
@@ -4201,13 +4208,15 @@ class BacktestApp:
         new_close: 0=new position, 1=close position, 2=auto (exchange decides).
         exit_type: "limit" (TP), "stop" (SL), "close", "force_close", or "".
         exit_limit: strategy's original limit price for take-profit exits.
+
+        Returns True if order was accepted (code==0), False otherwise.
         """
         if not _com_available or skO is None:
             self._live_log_msg("實單失敗 Order FAILED: COM not available", "exit")
-            return
+            return False
         if not self._futures_account:
             self._live_log_msg("實單失敗 Order FAILED: no futures account", "exit")
-            return
+            return False
 
         # Margin check for new positions (entries)
         if action_type == "entry" and self._account_monitor.rights:
@@ -4222,7 +4231,7 @@ class BacktestApp:
                     self._live_log_msg(msg, "exit")
                     self._log_order_decision("REAL_ORDER_BLOCKED", msg)
                     _log(f"REAL ORDER BLOCKED: {msg}")
-                    return
+                    return False
             except (ValueError, TypeError):
                 pass  # can't parse — proceed with order, let exchange decide
 
@@ -4298,6 +4307,7 @@ class BacktestApp:
                     "REAL_ORDER_SENT",
                     f"{side_str} {order_symbol} x1 {price_label} sim={sim_price}",
                 )
+                return True
             else:
                 err_msg = skC.SKCenterLib_GetReturnCodeMessage(code) if skC else str(code)
                 self._live_log_msg(f"實單失敗 Order FAILED: code={code} {err_msg} | {message}", "exit")
@@ -4308,11 +4318,53 @@ class BacktestApp:
                     "REAL_ORDER_FAILED",
                     f"code={code} {err_msg}",
                 )
+                return False
 
         except Exception as e:
             self._live_log_msg(f"實單異常 Order error: {e}", "exit")
             _log(f"REAL ORDER ERROR: {e}\n{traceback.format_exc()}")
             self._log_order_decision("REAL_ORDER_ERROR", str(e))
+            return False
+
+    def _retry_force_close(self, buy_sell, order_symbol, sim_price,
+                           attempt, max_attempts, last_error):
+        """Retry a failed force-close order with escalating delays.
+
+        On retry, falls back to sNewClose=2 (auto) in case sNewClose=1 was
+        rejected. After all retries exhausted, emits loud alarm and does NOT
+        mark simulated broker as flat (prevents sim/real divergence).
+        """
+        if attempt > max_attempts:
+            # All retries exhausted — loud alarm
+            msg = (f"強制平倉全部失敗 FORCE CLOSE ALL RETRIES FAILED "
+                   f"({max_attempts} attempts) last_error={last_error}")
+            _log(f"CRITICAL: {msg}")
+            self._live_log_msg(f"🚨 {msg}", "exit")
+            print(f"\n{'='*60}")
+            print(f"CRITICAL: FORCE CLOSE FAILED — POSITION MAY STILL BE OPEN")
+            print(f"Symbol: {order_symbol} | Attempts: {max_attempts}")
+            print(f"Last error: {last_error}")
+            print(f"IMMEDIATE MANUAL INTERVENTION REQUIRED")
+            print(f"{'='*60}\n")
+            if _discord and _discord.enabled:
+                _discord.force_close_failed(order_symbol, max_attempts, last_error)
+            return
+
+        _log(f"FORCE CLOSE RETRY {attempt}/{max_attempts} for {order_symbol}")
+        self._live_log_msg(
+            f"強制平倉重試 Force close retry {attempt}/{max_attempts}", "exit")
+
+        # Retry with sNewClose=2 (auto) as fallback — sNewClose=1 may have
+        # been rejected if position was already partially closed
+        ok = self._send_real_order(
+            buy_sell, order_symbol, "exit", sim_price,
+            new_close=2, exit_type="force_close")
+
+        if not ok:
+            delay = self._FORCE_CLOSE_RETRY_DELAYS[attempt - 1] if attempt <= len(self._FORCE_CLOSE_RETRY_DELAYS) else 15000
+            self.root.after(delay, self._retry_force_close,
+                            buy_sell, order_symbol, sim_price,
+                            attempt + 1, max_attempts, last_error)
 
     # ── Fill confirmation via OpenInterest position change (auto mode) ──
     #
@@ -4542,7 +4594,7 @@ class BacktestApp:
         elif self._last_real_order_side is not None:
             buy_sell = 1 - self._last_real_order_side
         elif self._live_runner.broker.position_size != 0:
-            side = self._live_runner.broker.trades[-1].side.value if self._live_runner.broker.trades else "LONG"
+            side = self._live_runner.broker.position_side.value if self._live_runner.broker.position_side else "LONG"
             buy_sell = 1 if side == "LONG" else 0
         else:
             self._live_log_msg("無持倉紀錄 No position record — use BUY or SELL directly", "status")

--- a/src/live/discord_notify.py
+++ b/src/live/discord_notify.py
@@ -106,6 +106,15 @@ class DiscordNotifier:
             f"交易: {trades} 筆 | P&L: {pnl:+,}"
         )
 
+    def force_close_failed(self, symbol: str, attempts: int, last_error: str) -> None:
+        self._send(
+            f"{self._header()}\n"
+            f"🚨 **強制平倉失敗 FORCE CLOSE FAILED** 🚨\n"
+            f"商品: `{symbol}` | 重試: {attempts} 次\n"
+            f"最後錯誤: {last_error}\n"
+            f"**需要立即人工介入！Position may still be open!**"
+        )
+
     def daily_loss_limit(self, net_pnl: int, limit: int) -> None:
         self._send(
             f"{self._header()}\n"

--- a/src/live/trading_guard.py
+++ b/src/live/trading_guard.py
@@ -191,10 +191,18 @@ class TradingGuard:
             buy_sell = 1 if side == "LONG" else 0  # reverse to close
             action_type = "exit"
 
+        # Force-close: use sNewClose=1 (explicit close) instead of 2 (auto).
+        # We KNOW a position exists (caller checked position_side), and auto
+        # can misclassify close as open, causing error 980 (insufficient margin).
+        if action == "FORCE_CLOSE":
+            new_close = 1
+        else:
+            new_close = self.order_params(action_type)["new_close"]
+
         details = {
             "buy_sell": buy_sell,
             "action_type": action_type,
-            "new_close": self.order_params(action_type)["new_close"],
+            "new_close": new_close,
         }
 
         # Fill confirmation gate (blocks entries and normal exits)

--- a/tests/test_session_end_close_direction.py
+++ b/tests/test_session_end_close_direction.py
@@ -1,0 +1,233 @@
+"""Regression tests for session-end force-close direction bug.
+
+The bug: _check_session_end_close read `broker.trades[-1].side` (the PREVIOUS
+completed trade) instead of `broker.position_side` (the CURRENT open position).
+This caused force-close to compute the wrong buy_sell direction, sending an
+order that OPENS a second position instead of closing the existing one.
+
+Incident: 2026-04-14 04:58:26 night session close — error 980 (insufficient
+margin) because the close order went in the same direction as the position.
+"""
+
+import pytest
+
+from src.backtest.broker import SimulatedBroker, BrokerContext, OrderSide
+from src.live.trading_guard import TradingGuard
+
+
+# ── Helpers ──
+
+def _make_broker_with_position(side: OrderSide, prior_trades: list[OrderSide] | None = None):
+    """Create a broker with an open position, optionally preceded by closed trades.
+
+    Args:
+        side: the side of the CURRENT open position (LONG or SHORT).
+        prior_trades: list of sides for prior completed trades (closed before
+            the current position was opened).
+
+    Returns:
+        (broker, ctx) with the open position active.
+    """
+    broker = SimulatedBroker(point_value=200)
+    ctx = BrokerContext(broker)
+    bar = 0
+
+    # Fill prior trades (each: entry -> fill -> close)
+    for prior_side in (prior_trades or []):
+        ctx.entry(f"prior_{bar}", prior_side)
+        broker.on_bar_close(bar, 20000)
+        bar += 1
+        # Close via force_close to keep it simple
+        broker.force_close(bar, 20050, f"2026-01-01 09:{bar:02d}")
+        bar += 1
+
+    # Open the current position
+    ctx.entry("current", side)
+    broker.on_bar_close(bar, 20100)
+    bar += 1
+
+    assert broker.position_size == 1, "Position must be open"
+    assert broker.position_side == side, f"Expected {side}, got {broker.position_side}"
+    return broker, ctx
+
+
+# ── Tests: position_side gives the correct direction ──
+
+class TestPositionSideDirection:
+    """Verify that broker.position_side reflects the CURRENT open position,
+    not the last completed trade."""
+
+    def test_long_position_no_prior_trades(self):
+        """LONG position, no prior trades: side should be LONG (not empty)."""
+        broker, _ = _make_broker_with_position(OrderSide.LONG)
+        side = broker.position_side.value if broker.position_side else ""
+        assert side == "LONG"
+
+    def test_long_position_with_prior_short(self):
+        """LONG position after a completed SHORT trade: side should be LONG (not SHORT).
+
+        This is the exact scenario that caused the incident — trades[-1].side
+        was SHORT (the previous trade), but the open position is LONG.
+        """
+        broker, _ = _make_broker_with_position(
+            OrderSide.LONG, prior_trades=[OrderSide.SHORT])
+        # Bug: trades[-1].side.value would return "SHORT" (wrong!)
+        assert broker.trades[-1].side == OrderSide.SHORT, "Prior trade was SHORT"
+        # Fix: position_side returns the CURRENT position
+        side = broker.position_side.value if broker.position_side else ""
+        assert side == "LONG"
+
+    def test_short_position_no_prior_trades(self):
+        """SHORT position, no prior trades: side should be SHORT."""
+        broker, _ = _make_broker_with_position(OrderSide.SHORT)
+        side = broker.position_side.value if broker.position_side else ""
+        assert side == "SHORT"
+
+    def test_short_position_with_prior_long(self):
+        """SHORT position after a completed LONG trade: side should be SHORT (not LONG)."""
+        broker, _ = _make_broker_with_position(
+            OrderSide.SHORT, prior_trades=[OrderSide.LONG])
+        assert broker.trades[-1].side == OrderSide.LONG, "Prior trade was LONG"
+        side = broker.position_side.value if broker.position_side else ""
+        assert side == "SHORT"
+
+    def test_flat_position(self):
+        """No open position: side should be empty string."""
+        broker = SimulatedBroker(point_value=200)
+        side = broker.position_side.value if broker.position_side else ""
+        assert side == ""
+
+    def test_flat_after_close_with_trades(self):
+        """After closing a LONG, position_side is None even though trades exist."""
+        broker, _ = _make_broker_with_position(OrderSide.LONG)
+        broker.force_close(10, 20200, "2026-01-01 10:00")
+        assert broker.position_size == 0
+        assert broker.position_side is None
+        # trades[-1] still has the old side — this is what the bug read
+        assert broker.trades[-1].side == OrderSide.LONG
+
+
+# ── Tests: TradingGuard.decide computes correct buy_sell ──
+
+class TestForceCloseDecisionDirection:
+    """Verify that TradingGuard.decide() produces the correct buy_sell
+    for force-close given the position side."""
+
+    def test_long_force_close_sends_sell(self):
+        """LONG position force-close: buy_sell should be 1 (SELL)."""
+        guard = TradingGuard()
+        guard.on_entry_sent()  # mark real position exists
+        _, details = guard.decide("auto", "FORCE_CLOSE", "LONG")
+        assert details["buy_sell"] == 1, "LONG force-close must SELL (1)"
+        assert details["action_type"] == "exit"
+
+    def test_short_force_close_sends_buy(self):
+        """SHORT position force-close: buy_sell should be 0 (BUY)."""
+        guard = TradingGuard()
+        guard.on_entry_sent()
+        _, details = guard.decide("auto", "FORCE_CLOSE", "SHORT")
+        assert details["buy_sell"] == 0, "SHORT force-close must BUY (0)"
+        assert details["action_type"] == "exit"
+
+    def test_wrong_side_produces_wrong_direction(self):
+        """Demonstrate the bug: if side="" (from empty trades), buy_sell=0 (BUY).
+
+        For a LONG position, the correct close is SELL (1). If the buggy code
+        reads side="" because trades is empty, decide() gets "" which falls
+        into the `else` branch and produces buy_sell=0 (BUY) — opening a
+        second position instead of closing.
+        """
+        guard = TradingGuard()
+        guard.on_entry_sent()
+        _, details = guard.decide("auto", "FORCE_CLOSE", "")
+        # With side="", the code does: buy_sell = 1 if "" == "LONG" else 0 → 0 (BUY)
+        assert details["buy_sell"] == 0, "Empty side falls through to BUY"
+        # This is WRONG for a LONG position — it should be SELL (1)
+
+    def test_swapped_side_produces_wrong_direction(self):
+        """Demonstrate the bug: prior SHORT trade + current LONG position.
+
+        If buggy code reads trades[-1].side = "SHORT", decide() computes
+        buy_sell = 1 if "SHORT" == "LONG" else 0 → 0 (BUY).
+        For a LONG position, correct close is SELL (1). BUY opens a second
+        position → error 980 (insufficient margin).
+        """
+        guard = TradingGuard()
+        guard.on_entry_sent()
+        _, details = guard.decide("auto", "FORCE_CLOSE", "SHORT")
+        assert details["buy_sell"] == 0, "SHORT close = BUY (0)"
+        # If the position is actually LONG, this BUY is WRONG
+
+
+# ── Tests: force-close uses sNewClose=1 (explicit close) ──
+
+class TestForceCloseNewClose:
+    """Verify that FORCE_CLOSE uses sNewClose=1, not 2 (auto)."""
+
+    def test_force_close_uses_explicit_close(self):
+        guard = TradingGuard()
+        guard.on_entry_sent()
+        _, details = guard.decide("auto", "FORCE_CLOSE", "LONG")
+        assert details["new_close"] == 1, "Force-close must use sNewClose=1 (explicit close)"
+
+    def test_normal_exit_uses_auto(self):
+        guard = TradingGuard()
+        guard.on_entry_sent()
+        _, details = guard.decide("auto", "TRADE_CLOSE", "LONG")
+        assert details["new_close"] == 2, "Normal exit uses sNewClose=2 (auto)"
+
+    def test_entry_uses_new(self):
+        guard = TradingGuard()
+        _, details = guard.decide("auto", "ENTRY_FILL", "LONG")
+        assert details["new_close"] == 0, "Entry uses sNewClose=0 (new)"
+
+
+# ── Integration: full flow from broker state to decide() ──
+
+class TestEndToEndForceCloseDirection:
+    """Full integration: create broker state, extract side, pass to decide()."""
+
+    @pytest.mark.parametrize("current_side,prior_sides,expected_buy_sell", [
+        (OrderSide.LONG, [], 1),              # LONG → SELL
+        (OrderSide.LONG, [OrderSide.SHORT], 1),  # prior SHORT, current LONG → SELL
+        (OrderSide.SHORT, [], 0),             # SHORT → BUY
+        (OrderSide.SHORT, [OrderSide.LONG], 0),  # prior LONG, current SHORT → BUY
+        (OrderSide.LONG, [OrderSide.LONG, OrderSide.SHORT], 1),  # multiple priors
+        (OrderSide.SHORT, [OrderSide.SHORT, OrderSide.LONG], 0),
+    ])
+    def test_position_side_to_decide(self, current_side, prior_sides, expected_buy_sell):
+        """End-to-end: broker.position_side → decide() → correct buy_sell."""
+        broker, _ = _make_broker_with_position(current_side, prior_trades=prior_sides)
+
+        # This is the FIXED code path:
+        side = broker.position_side.value if broker.position_side else ""
+
+        guard = TradingGuard()
+        guard.on_entry_sent()
+        _, details = guard.decide("auto", "FORCE_CLOSE", side)
+        assert details["buy_sell"] == expected_buy_sell, (
+            f"current={current_side.value} priors={[s.value for s in prior_sides]} "
+            f"→ expected buy_sell={expected_buy_sell}, got {details['buy_sell']}")
+
+    @pytest.mark.parametrize("current_side,prior_sides", [
+        (OrderSide.LONG, [OrderSide.SHORT]),
+        (OrderSide.SHORT, [OrderSide.LONG]),
+    ])
+    def test_buggy_code_would_fail(self, current_side, prior_sides):
+        """Prove that the OLD buggy code (trades[-1].side) gives WRONG direction."""
+        broker, _ = _make_broker_with_position(current_side, prior_trades=prior_sides)
+
+        # BUGGY path: reads last completed trade's side
+        buggy_side = broker.trades[-1].side.value if broker.trades else ""
+        # FIXED path: reads current open position's side
+        fixed_side = broker.position_side.value if broker.position_side else ""
+
+        assert buggy_side != fixed_side, (
+            f"Bug scenario: trades[-1].side={buggy_side} != position_side={fixed_side}")
+
+        guard = TradingGuard()
+        guard.on_entry_sent()
+        _, buggy_details = guard.decide("auto", "FORCE_CLOSE", buggy_side)
+        _, fixed_details = guard.decide("auto", "FORCE_CLOSE", fixed_side)
+        assert buggy_details["buy_sell"] != fixed_details["buy_sell"], (
+            "Buggy and fixed code should produce DIFFERENT buy_sell in this scenario")

--- a/tests/test_trading_safety.py
+++ b/tests/test_trading_safety.py
@@ -140,7 +140,7 @@ class TestDecideExitSent:
         verdict, details = g.decide("auto", "FORCE_CLOSE", "SHORT")
         assert verdict == g.SEND_EXIT
         assert details["buy_sell"] == 0  # buy to close short
-        assert details["new_close"] == 2  # auto
+        assert details["new_close"] == 1  # explicit close (we KNOW position exists)
 
     def test_exit_resets_entry_flag_via_on_exit_sent(self):
         """After SEND_EXIT, calling on_exit_sent() should block next exit."""
@@ -235,12 +235,13 @@ class TestDecideNewClose:
             assert d["new_close"] == 0, f"{mode}/ENTRY_FILL"
 
     def test_exit_uses_auto_newclose(self):
-        """Exit orders use new_close=2 (auto) to avoid 980 when already flat."""
+        """Normal exits use new_close=2 (auto), force-close uses 1 (explicit)."""
         g = TradingGuard()
         g.on_entry_sent()
-        for action in ("TRADE_CLOSE", "FORCE_CLOSE"):
-            _, d = g.decide("auto", action, "LONG")
-            assert d["new_close"] == 2, f"auto/{action}"
+        _, d = g.decide("auto", "TRADE_CLOSE", "LONG")
+        assert d["new_close"] == 2, "TRADE_CLOSE uses auto"
+        _, d = g.decide("auto", "FORCE_CLOSE", "LONG")
+        assert d["new_close"] == 1, "FORCE_CLOSE uses explicit close"
 
 
 # ── TradingGuard: margin check ──

--- a/version.py
+++ b/version.py
@@ -1,3 +1,3 @@
 """Single source of truth for app version."""
 
-APP_VERSION = "2.6.0"
+APP_VERSION = "2.6.1"


### PR DESCRIPTION
## Summary

Fixes critical force-close direction bug that caused session-end auto-close orders to go in the WRONG direction, opening a second position instead of closing (error 980 — insufficient margin). Relates to #54.

- **Root cause**: `_check_session_end_close` read `broker.trades[-1].side` (previous completed trade's direction) instead of `broker.position_side` (current open position). When the previous trade was opposite direction, the close order went the wrong way.
- **Same bug in `_manual_close`**: The fallback path for the manual close button had the identical pattern.
- **`sNewClose` fix**: Force-close now uses `sNewClose=1` (explicit close) instead of `2` (auto) to prevent exchange misclassification — directly addresses collaborator's suspicion in #54.
- **Retry with alarm**: Force-close failures now retry up to 3 times (5/10/15s delays), falling back to `sNewClose=2` on retry. If all retries fail: logger.error + Discord critical alert + console alarm. Simulated broker is NOT marked flat to prevent sim/real divergence.
- **21 regression tests** covering direction computation end-to-end, including parametrized tests that prove the old code produces wrong results.

## Changes

| File | Change |
|------|--------|
| `run_backtest.py:3752` | `trades[-1].side` → `position_side` in `_check_session_end_close` |
| `run_backtest.py:4545` | `trades[-1].side` → `position_side` in `_manual_close` fallback |
| `src/live/trading_guard.py` | FORCE_CLOSE uses `sNewClose=1` (explicit close) |
| `run_backtest.py` | `_retry_force_close()` with 3 retries + loud alarm on exhaustion |
| `src/live/discord_notify.py` | `force_close_failed()` critical alert method |
| `tests/test_session_end_close_direction.py` | 21 new regression tests |
| `tests/test_trading_safety.py` | Updated existing tests for new sNewClose=1 behavior |
| `version.py` | 2.6.0 → 2.6.1 |

## Test plan

- [x] All 784 tests pass (5 skipped — session replay tests)
- [x] 21 new regression tests verify correct direction in all scenarios
- [x] Tests prove old code (`trades[-1].side`) gives wrong direction when prior trade is opposite
- [x] Tests verify `sNewClose=1` for FORCE_CLOSE, `sNewClose=2` for normal exits
- [ ] Manual verification: deploy bot, wait for session-end close, verify SELL order sent for LONG position

🤖 Generated with [Claude Code](https://claude.com/claude-code)