### PR TITLE
fix: reduce AI API spend — token trimming, usage logging, model tiers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,7 @@ logs/
 *.db
 backtest_trades_*.csv
 
-# Live runtime logs
+# Live runtime logs (incl. data/ai_usage.csv — per-machine token spend log)
 data/
 
 # Broker order dumps

--- a/run_backtest.py
+++ b/run_backtest.py
@@ -3221,15 +3221,20 @@ class BacktestApp:
                         # Final response is the real analysis
                         self.root.after(0, lambda r=response: self._on_chat_response(r))
                     else:
-                        # Log a short ack line for visibility, no big chat bubble
-                        ack_preview = response.strip().split("\n", 1)[0][:120]
+                        # Log a short ack line for visibility, no big chat bubble.
+                        # chat_client appends a "📊 tokens: ..." footer to every
+                        # response — surface it here too so per-batch spend is
+                        # visible on intermediate acks, not just the final one.
+                        lines = response.strip().split("\n")
+                        ack_preview = lines[0][:120] if lines else ""
+                        token_line = next(
+                            (ln for ln in lines if ln.startswith("📊")), "")
+                        ack_display = f"[AI Review part {batch_idx}/{K} ack] {ack_preview}"
+                        if token_line:
+                            ack_display += f"  {token_line}"
                         self.root.after(
                             0,
-                            lambda p=ack_preview, b=batch_idx, k=K:
-                                self._append_chat(
-                                    "system",
-                                    f"[AI Review part {b}/{k} ack] {p}",
-                                )
+                            lambda d=ack_display: self._append_chat("system", d),
                         )
             except Exception as e:
                 _log(f"Review chunked error: [{type(e).__name__}] {e}\n{traceback.format_exc()}")

--- a/run_backtest.py
+++ b/run_backtest.py
@@ -76,7 +76,10 @@ from src.strategy.examples.m1_bollinger_atr_long import M1BollingerAtrLongStrate
 from src.strategy.examples.m1_sma_cross import M1SmaCrossStrategy
 
 # AI modules
-from src.ai.chat_client import ChatClient, PROVIDER_ANTHROPIC, PROVIDER_GOOGLE, DEFAULT_MODELS
+from src.ai.chat_client import (
+    ChatClient, PROVIDER_ANTHROPIC, PROVIDER_GOOGLE, DEFAULT_MODELS,
+    model_for_tier,
+)
 from src.ai.prompts import STRATEGY_SYSTEM_PROMPT, STRATEGY_CODE_CONTEXT, CODE_GEN_SYSTEM_PROMPT, CHAT_RECAP_PROMPT
 from src.ai.code_sandbox import (
     extract_python_code, load_strategy_from_source,
@@ -85,8 +88,10 @@ from src.ai.code_sandbox import (
 from src.ai.strategy_store import StrategyStore
 from src.ai.pine_exporter import export_to_pine
 
-# Code generation uses higher token limit to avoid truncation (issue #7)
-_CODE_GEN_MAX_TOKENS = 65536
+# Code generation max output tokens.  Strategies are typically <300 lines,
+# so 16K output tokens is plenty.  Lower cap keeps the per-call price low
+# (Gemini bills generous output token budgets even when the response is short).
+_CODE_GEN_MAX_TOKENS = 16384
 
 # Live trading modules
 from src.live.live_runner import LiveRunner, LiveState, is_market_open, seconds_until_market_open, minutes_until_session_close, _taipei_now, _TZ_TAIPEI
@@ -266,6 +271,7 @@ def _load_settings():
             cfg["google_api_key"] = ai.get("google_api_key", "")
             cfg["ai_model"] = ai.get("model", "")
             cfg["ai_max_tokens"] = ai.get("max_tokens", 16384)
+            cfg["recap_token_gate"] = ai.get("recap_token_gate", 30)
             # Notifications
             notif = data.get("notifications", {})
             cfg["discord_bot_token"] = notif.get("discord_bot_token", "")
@@ -1294,9 +1300,13 @@ class BacktestApp:
         self.btn_send.config(state=tk.DISABLED)
         self._append_chat("system", "Thinking...")
 
+        chat_model = model_for_tier(
+            self._settings.get("ai_provider", PROVIDER_ANTHROPIC), "light")
+
         def _worker():
             try:
-                response = self._chat_client.send_message(text)
+                response = self._chat_client.send_message(
+                    text, call_site="chat", model=chat_model)
                 self.root.after(0, lambda: self._on_chat_response(response))
             except Exception as e:
                 _log(f"Chat error: [{type(e).__name__}] {e}\n{traceback.format_exc()}")
@@ -1400,11 +1410,16 @@ class BacktestApp:
 
         # Use a one-shot API call (not the chat conversation) to avoid bloat
         client = self._chat_client
+        codegen_model = model_for_tier(
+            self._settings.get("ai_provider", PROVIDER_ANTHROPIC), "heavy")
 
         def _worker():
             try:
-                response = client.one_shot(gen_msg, system_prompt=CODE_GEN_SYSTEM_PROMPT,
-                                          max_tokens=_CODE_GEN_MAX_TOKENS)
+                response = client.one_shot(
+                    gen_msg, system_prompt=CODE_GEN_SYSTEM_PROMPT,
+                    max_tokens=_CODE_GEN_MAX_TOKENS,
+                    call_site="codegen", model=codegen_model,
+                )
                 self.root.after(0, lambda: self._on_generate_response(response))
             except Exception as e:
                 _log(f"Generate error: [{type(e).__name__}] {e}\n{traceback.format_exc()}")
@@ -1482,11 +1497,16 @@ class BacktestApp:
         ) if summary else ""
         retry_msg = summary_section + error_msg + "\n\n" + STRATEGY_CODE_CONTEXT
         remaining = retries_left - 1
+        codegen_model = model_for_tier(
+            self._settings.get("ai_provider", PROVIDER_ANTHROPIC), "heavy")
 
         def _worker():
             try:
-                resp = self._chat_client.one_shot(retry_msg, system_prompt=CODE_GEN_SYSTEM_PROMPT,
-                                                  max_tokens=_CODE_GEN_MAX_TOKENS)
+                resp = self._chat_client.one_shot(
+                    retry_msg, system_prompt=CODE_GEN_SYSTEM_PROMPT,
+                    max_tokens=_CODE_GEN_MAX_TOKENS,
+                    call_site="codegen_retry", model=codegen_model,
+                )
                 self.root.after(0, lambda: self._on_generate_response(resp, retries_left=remaining))
             except Exception as e:
                 _log(f"Retry error: [{type(e).__name__}] {e}\n{traceback.format_exc()}")
@@ -1870,12 +1890,30 @@ class BacktestApp:
         if not self._chat_client:
             return
 
+        # Recap size gate: skip when the conversation is already large.  A
+        # recap re-sends the entire history just to get a summary back, so on
+        # long sessions the cost outweighs the benefit.
+        gate = int(self._settings.get("recap_token_gate", 30) or 30)
+        n_msgs = len(self._chat_client.conversation)
+        if n_msgs > gate:
+            self._append_chat(
+                "system",
+                f"略過上下文回顧 Skipping recap "
+                f"({n_msgs} messages > recap_token_gate={gate}; "
+                f"would be expensive on long sessions).",
+            )
+            return
+
         self._append_chat("system", "正在回顧對話上下文 Recapping conversation context...")
         self.btn_send.config(state=tk.DISABLED)
 
+        recap_model = model_for_tier(
+            self._settings.get("ai_provider", PROVIDER_ANTHROPIC), "light")
+
         def _worker():
             try:
-                response = self._chat_client.send_message(CHAT_RECAP_PROMPT)
+                response = self._chat_client.send_message(
+                    CHAT_RECAP_PROMPT, call_site="recap", model=recap_model)
                 # Remove the recap prompt from conversation so it doesn't pollute saves.
                 # send_message appends user + assistant, remove both and just keep assistant.
                 conv = self._chat_client.conversation
@@ -3039,9 +3077,21 @@ class BacktestApp:
         self.btn_send.config(state=tk.DISABLED)
         self._append_chat("system", f"Analyzing {total_trades} trades...")
 
+        review_model = model_for_tier(
+            self._settings.get("ai_provider", PROVIDER_ANTHROPIC), "heavy")
+
         def _worker():
             try:
-                response = self._chat_client.send_message(context)
+                response = self._chat_client.send_message(
+                    context, call_site="trade_review", model=review_model)
+                # Replace the trade-dump user turn with a stub so the trade
+                # data does not pollute future send_message() calls (issue: AI
+                # cost runaway because send_message re-sends full history).
+                conv = self._chat_client.conversation
+                if len(conv) >= 2 and conv[-2].get("role") == "user":
+                    conv[-2]["content"] = (
+                        f"[trade review payload — {total_trades} trades, trimmed to save tokens]"
+                    )
                 self.root.after(0, lambda: self._on_chat_response(response))
             except Exception as e:
                 _log(f"Review error: [{type(e).__name__}] {e}\n{traceback.format_exc()}")
@@ -3087,6 +3137,9 @@ class BacktestApp:
             f"Sending {total_trades} trades to AI in {K} parts "
             f"({batch_size} trades/part). Final analysis arrives after part {K}."
         )
+
+        review_model = model_for_tier(
+            self._settings.get("ai_provider", PROVIDER_ANTHROPIC), "heavy")
 
         def _worker():
             try:
@@ -3149,7 +3202,20 @@ class BacktestApp:
                             self.status_var.set(f"AI Review: sending part {b}/{k}...")
                     )
 
-                    response = self._chat_client.send_message(msg)
+                    response = self._chat_client.send_message(
+                        msg, call_site=f"trade_review_chunk_{batch_idx}/{K}",
+                        model=review_model,
+                    )
+
+                    # Replace this batch's user turn with a stub so the giant
+                    # trade payload doesn't get re-sent on subsequent calls.
+                    conv = self._chat_client.conversation
+                    if len(conv) >= 2 and conv[-2].get("role") == "user":
+                        conv[-2]["content"] = (
+                            f"[trade review payload — part {batch_idx}/{K}, "
+                            f"trades {start_n}-{end_n} of {total_trades}, "
+                            f"trimmed to save tokens]"
+                        )
 
                     if is_last:
                         # Final response is the real analysis

--- a/settings.example.yaml
+++ b/settings.example.yaml
@@ -50,3 +50,7 @@ ai:
   google_api_key: ""             # AIza... (from aistudio.google.com/apikey)
   model: ""                      # leave empty for default (Sonnet 4 / Gemini 2.5 Pro)
   max_tokens: 4096
+  # Skip the post-load context recap when the loaded conversation already has
+  # more than this many messages.  A recap re-sends the full history; on long
+  # sessions that's expensive and rarely worth it.
+  recap_token_gate: 30

--- a/src/ai/chat_client.py
+++ b/src/ai/chat_client.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
+import csv
+import logging
+import os
+from datetime import datetime, timezone
+
 import httpx
 
 
@@ -19,6 +24,78 @@ DEFAULT_MODELS = {
     PROVIDER_ANTHROPIC: "claude-sonnet-4-20250514",
     PROVIDER_GOOGLE: "gemini-2.5-pro",
 }
+
+# Tiered Gemini models — used by callers that want to pick light vs heavy reasoning.
+GOOGLE_MODEL_PRO = "gemini-2.5-pro"
+GOOGLE_MODEL_FLASH = "gemini-2.5-flash"
+
+# Auto-truncate conversation when its total char size exceeds this threshold
+# in send_message().  The first message is always kept; the most recent N
+# messages that fit are kept, older ones in the middle are dropped.
+_CONVERSATION_CHAR_LIMIT = 200_000
+
+# Where token-usage rows are appended.  Caller can override via env var for tests.
+_USAGE_LOG_PATH = os.environ.get(
+    "TAI_AI_USAGE_LOG",
+    os.path.join(os.getcwd(), "data", "ai_usage.csv"),
+)
+_USAGE_LOG_HEADERS = [
+    "timestamp", "call_site", "provider", "model",
+    "input_tokens", "output_tokens", "total_tokens",
+]
+
+_log = logging.getLogger(__name__)
+
+
+def model_for_tier(provider: str, tier: str) -> str | None:
+    """Return a tier-appropriate model override, or None to use the user default.
+
+    ``tier`` is ``"light"`` (cheap/fast: chat, recap) or ``"heavy"``
+    (quality matters: codegen, trade review).  For non-Google providers we
+    return None so the user-configured model is preserved (Anthropic users pick
+    their own model in settings).
+    """
+    if provider == PROVIDER_GOOGLE:
+        if tier == "light":
+            return GOOGLE_MODEL_FLASH
+        return GOOGLE_MODEL_PRO
+    return None
+
+
+def _log_token_usage(
+    *, call_site: str, provider: str, model: str,
+    input_tokens: int, output_tokens: int,
+) -> None:
+    """Append one row to ``data/ai_usage.csv``.  Best-effort — never raises."""
+    try:
+        path = _USAGE_LOG_PATH
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        new_file = not os.path.exists(path)
+        with open(path, "a", newline="", encoding="utf-8") as f:
+            w = csv.writer(f)
+            if new_file:
+                w.writerow(_USAGE_LOG_HEADERS)
+            w.writerow([
+                datetime.now(timezone.utc).isoformat(timespec="seconds"),
+                call_site,
+                provider,
+                model,
+                int(input_tokens or 0),
+                int(output_tokens or 0),
+                int((input_tokens or 0) + (output_tokens or 0)),
+            ])
+    except Exception as e:  # pragma: no cover — logging failure must not break callers
+        _log.debug("Failed to write AI usage log: %s", e)
+
+
+def _extract_anthropic_usage(data: dict) -> tuple[int, int]:
+    usage = data.get("usage") or {}
+    return int(usage.get("input_tokens", 0)), int(usage.get("output_tokens", 0))
+
+
+def _extract_google_usage(data: dict) -> tuple[int, int]:
+    meta = data.get("usageMetadata") or {}
+    return int(meta.get("promptTokenCount", 0)), int(meta.get("candidatesTokenCount", 0))
 
 
 class ChatClient:
@@ -47,27 +124,71 @@ class ChatClient:
     def set_system_prompt(self, prompt: str) -> None:
         self.system_prompt = prompt
 
-    def send_message(self, user_message: str) -> str:
+    def _enforce_conversation_size(self) -> None:
+        """If conversation chars exceed _CONVERSATION_CHAR_LIMIT, drop oldest
+        middle messages, keeping conversation[0] and the most recent tail.
+        """
+        conv = self.conversation
+        total = sum(len(m.get("content", "")) for m in conv)
+        if total <= _CONVERSATION_CHAR_LIMIT or len(conv) <= 2:
+            return
+
+        first = conv[0]
+        first_size = len(first.get("content", ""))
+        budget = _CONVERSATION_CHAR_LIMIT - first_size
+
+        kept_tail: list[dict] = []
+        running = 0
+        # Walk from the end, keep as many recent messages as fit.
+        for msg in reversed(conv[1:]):
+            size = len(msg.get("content", ""))
+            if running + size > budget and kept_tail:
+                break
+            kept_tail.append(msg)
+            running += size
+        kept_tail.reverse()
+
+        dropped = len(conv) - 1 - len(kept_tail)
+        if dropped <= 0:
+            return
+
+        new_conv = [first] + kept_tail
+        self.conversation = new_conv
+        _log.warning(
+            "ChatClient: conversation auto-truncated (%d chars > %d); "
+            "kept first message + last %d of %d, dropped %d middle messages.",
+            total, _CONVERSATION_CHAR_LIMIT, len(kept_tail), len(conv) - 1, dropped,
+        )
+
+    def send_message(
+        self,
+        user_message: str,
+        *,
+        call_site: str = "unknown",
+        model: str | None = None,
+    ) -> str:
         """Send a message and return the assistant's response text.
 
         Blocking call — run from a background thread when used with Tkinter.
         """
         self.conversation.append({"role": "user", "content": user_message})
+        self._enforce_conversation_size()
 
         try:
             if self.provider == PROVIDER_GOOGLE:
-                return self._send_google(user_message)
+                return self._send_google(user_message, call_site=call_site, model=model)
             else:
-                return self._send_anthropic(user_message)
+                return self._send_anthropic(user_message, call_site=call_site, model=model)
         except Exception:
             # Remove the user message on failure
             self.conversation.pop()
             raise
 
-    def _send_anthropic(self, user_message: str) -> str:
+    def _send_anthropic(self, user_message: str, *, call_site: str, model: str | None) -> str:
         """Send via Anthropic API."""
+        used_model = model or self.model
         payload: dict = {
-            "model": self.model,
+            "model": used_model,
             "max_tokens": self.max_tokens,
             "messages": self.conversation,
         }
@@ -97,11 +218,19 @@ class ChatClient:
             if block.get("type") == "text":
                 assistant_text += block["text"]
 
+        in_tok, out_tok = _extract_anthropic_usage(data)
+        _log_token_usage(
+            call_site=call_site, provider=self.provider, model=used_model,
+            input_tokens=in_tok, output_tokens=out_tok,
+        )
+
         self.conversation.append({"role": "assistant", "content": assistant_text})
         return assistant_text
 
-    def _send_google(self, user_message: str) -> str:
+    def _send_google(self, user_message: str, *, call_site: str, model: str | None) -> str:
         """Send via Google Gemini API."""
+        used_model = model or self.model
+
         # Build Gemini conversation format
         contents = []
 
@@ -128,7 +257,7 @@ class ChatClient:
         if system_instruction:
             payload["system_instruction"] = system_instruction
 
-        url = GOOGLE_API_URL.format(model=self.model) + f"?key={self.api_key}"
+        url = GOOGLE_API_URL.format(model=used_model) + f"?key={self.api_key}"
         headers = {"content-type": "application/json"}
 
         response = self._client.post(url, json=payload, headers=headers)
@@ -151,6 +280,12 @@ class ChatClient:
                 if "text" in part:
                     assistant_text += part["text"]
 
+        in_tok, out_tok = _extract_google_usage(data)
+        _log_token_usage(
+            call_site=call_site, provider=self.provider, model=used_model,
+            input_tokens=in_tok, output_tokens=out_tok,
+        )
+
         self.conversation.append({"role": "assistant", "content": assistant_text})
 
         # Check if response was truncated
@@ -159,8 +294,15 @@ class ChatClient:
 
         return assistant_text
 
-    def one_shot(self, user_message: str, system_prompt: str | None = None,
-                 max_tokens: int | None = None) -> str:
+    def one_shot(
+        self,
+        user_message: str,
+        system_prompt: str | None = None,
+        max_tokens: int | None = None,
+        *,
+        call_site: str = "unknown",
+        model: str | None = None,
+    ) -> str:
         """Single API call without modifying conversation history.
 
         Uses the given system_prompt (or self.system_prompt if None).
@@ -170,13 +312,17 @@ class ChatClient:
         prompt = system_prompt if system_prompt is not None else self.system_prompt
         tokens = max_tokens or self.max_tokens
         if self.provider == PROVIDER_GOOGLE:
-            return self._one_shot_google(user_message, prompt, tokens)
-        return self._one_shot_anthropic(user_message, prompt, tokens)
+            return self._one_shot_google(user_message, prompt, tokens,
+                                         call_site=call_site, model=model)
+        return self._one_shot_anthropic(user_message, prompt, tokens,
+                                        call_site=call_site, model=model)
 
     def _one_shot_anthropic(self, user_message: str, system_prompt: str = "",
-                            max_tokens: int = 0) -> str:
+                            max_tokens: int = 0, *, call_site: str = "unknown",
+                            model: str | None = None) -> str:
+        used_model = model or self.model
         payload: dict = {
-            "model": self.model,
+            "model": used_model,
             "max_tokens": max_tokens or self.max_tokens,
             "messages": [{"role": "user", "content": user_message}],
         }
@@ -205,10 +351,18 @@ class ChatClient:
         for block in data.get("content", []):
             if block.get("type") == "text":
                 assistant_text += block["text"]
+
+        in_tok, out_tok = _extract_anthropic_usage(data)
+        _log_token_usage(
+            call_site=call_site, provider=self.provider, model=used_model,
+            input_tokens=in_tok, output_tokens=out_tok,
+        )
         return assistant_text
 
     def _one_shot_google(self, user_message: str, system_prompt: str = "",
-                         max_tokens: int = 0) -> str:
+                         max_tokens: int = 0, *, call_site: str = "unknown",
+                         model: str | None = None) -> str:
+        used_model = model or self.model
         contents = [{"role": "user", "parts": [{"text": user_message}]}]
 
         payload: dict = {
@@ -218,7 +372,7 @@ class ChatClient:
         if system_prompt:
             payload["system_instruction"] = {"parts": [{"text": system_prompt}]}
 
-        url = GOOGLE_API_URL.format(model=self.model) + f"?key={self.api_key}"
+        url = GOOGLE_API_URL.format(model=used_model) + f"?key={self.api_key}"
         headers = {"content-type": "application/json"}
 
         response = self._client.post(url, json=payload, headers=headers)
@@ -240,6 +394,12 @@ class ChatClient:
             for part in parts:
                 if "text" in part:
                     assistant_text += part["text"]
+
+        in_tok, out_tok = _extract_google_usage(data)
+        _log_token_usage(
+            call_site=call_site, provider=self.provider, model=used_model,
+            input_tokens=in_tok, output_tokens=out_tok,
+        )
 
         # Check if response was truncated
         if candidates and candidates[0].get("finishReason") == "MAX_TOKENS":

--- a/src/ai/chat_client.py
+++ b/src/ai/chat_client.py
@@ -137,6 +137,19 @@ def _log_token_usage(
         _log.debug("Failed to write AI usage log: %s", e)
 
 
+def _format_usage_line(input_tokens: int, output_tokens: int,
+                       reasoning_tokens: int, total_tokens: int) -> str:
+    """One-line token-usage summary appended to the assistant response so the
+    user can see per-call spend in the chat UI without leaving the window.
+
+    Returns ``""`` when total is 0 (e.g. test mocks without usage data).
+    """
+    if total_tokens <= 0:
+        return ""
+    return (f"\n\n📊 tokens: {input_tokens:,} in / {output_tokens:,} out / "
+            f"{reasoning_tokens:,} reasoning (total: {total_tokens:,})")
+
+
 def _extract_anthropic_usage(data: dict) -> tuple[int, int, int, int]:
     """Return (input, output, reasoning, total) for an Anthropic response.
 
@@ -291,7 +304,10 @@ class ChatClient:
             reasoning_tokens=think_tok, total_tokens=tot_tok,
         )
 
+        # Conversation history holds the raw response — the usage line is
+        # caller-only so it doesn't bloat future API requests.
         self.conversation.append({"role": "assistant", "content": assistant_text})
+        assistant_text += _format_usage_line(in_tok, out_tok, think_tok, tot_tok)
         return assistant_text
 
     def _send_google(self, user_message: str, *, call_site: str, model: str | None) -> str:
@@ -354,11 +370,13 @@ class ChatClient:
             reasoning_tokens=think_tok, total_tokens=tot_tok,
         )
 
+        # Conversation history holds the raw response — annotations
+        # (truncation warning, usage line) are caller-only.
         self.conversation.append({"role": "assistant", "content": assistant_text})
 
-        # Check if response was truncated
         if candidates and candidates[0].get("finishReason") == "MAX_TOKENS":
             assistant_text += "\n\n[WARNING: Response truncated due to token limit]"
+        assistant_text += _format_usage_line(in_tok, out_tok, think_tok, tot_tok)
 
         return assistant_text
 
@@ -426,6 +444,7 @@ class ChatClient:
             input_tokens=in_tok, output_tokens=out_tok,
             reasoning_tokens=think_tok, total_tokens=tot_tok,
         )
+        assistant_text += _format_usage_line(in_tok, out_tok, think_tok, tot_tok)
         return assistant_text
 
     def _one_shot_google(self, user_message: str, system_prompt: str = "",
@@ -471,9 +490,9 @@ class ChatClient:
             reasoning_tokens=think_tok, total_tokens=tot_tok,
         )
 
-        # Check if response was truncated
         if candidates and candidates[0].get("finishReason") == "MAX_TOKENS":
             assistant_text += "\n\n[WARNING: Response truncated due to token limit]"
+        assistant_text += _format_usage_line(in_tok, out_tok, think_tok, tot_tok)
 
         return assistant_text
 

--- a/src/ai/chat_client.py
+++ b/src/ai/chat_client.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import csv
 import logging
 import os
+import sys
 from datetime import datetime, timezone
+from pathlib import Path
 
 import httpx
 
@@ -34,17 +36,33 @@ GOOGLE_MODEL_FLASH = "gemini-2.5-flash"
 # messages that fit are kept, older ones in the middle are dropped.
 _CONVERSATION_CHAR_LIMIT = 200_000
 
-# Where token-usage rows are appended.  Caller can override via env var for tests.
-_USAGE_LOG_PATH = os.environ.get(
-    "TAI_AI_USAGE_LOG",
-    os.path.join(os.getcwd(), "data", "ai_usage.csv"),
-)
+# CSV columns for the per-call usage log.  ``reasoning_tokens`` captures
+# Gemini 2.5's thoughtsTokenCount — these are billed at the output rate but
+# don't show up in candidatesTokenCount, so without this column the log
+# under-reports cost for any thinking-enabled model.
 _USAGE_LOG_HEADERS = [
     "timestamp", "call_site", "provider", "model",
-    "input_tokens", "output_tokens", "total_tokens",
+    "input_tokens", "output_tokens", "reasoning_tokens", "total_tokens",
 ]
 
+# Print one notice on the first write attempt so the user can confirm where
+# logging lives (or see the failure reason).  Toggled to True after first call.
+_usage_log_notified = False
+
 _log = logging.getLogger(__name__)
+
+
+def _resolve_usage_log_path() -> str:
+    """Where to append the per-call usage row.
+
+    Resolved at write time (not import time) so the path is robust against
+    cwd changes.  Override with TAI_AI_USAGE_LOG for tests/CI.
+    """
+    override = os.environ.get("TAI_AI_USAGE_LOG")
+    if override:
+        return override
+    # chat_client.py lives at <repo>/src/ai/chat_client.py
+    return str(Path(__file__).resolve().parents[2] / "data" / "ai_usage.csv")
 
 
 def model_for_tier(provider: str, tier: str) -> str | None:
@@ -65,37 +83,85 @@ def model_for_tier(provider: str, tier: str) -> str | None:
 def _log_token_usage(
     *, call_site: str, provider: str, model: str,
     input_tokens: int, output_tokens: int,
+    reasoning_tokens: int = 0, total_tokens: int = 0,
 ) -> None:
-    """Append one row to ``data/ai_usage.csv``.  Best-effort — never raises."""
+    """Append one row to ``data/ai_usage.csv``.  Best-effort — never raises.
+
+    ``total_tokens`` should be the provider's authoritative total when
+    available (Gemini's ``totalTokenCount`` already includes thinking).
+    Falls back to ``input + output + reasoning`` when zero.
+    """
+    global _usage_log_notified
+    path = _resolve_usage_log_path()
     try:
-        path = _USAGE_LOG_PATH
-        os.makedirs(os.path.dirname(path), exist_ok=True)
+        parent = os.path.dirname(path)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+
+        # If a pre-existing file uses an older/different header, archive it
+        # so we don't append rows with mismatched columns.
+        if os.path.exists(path):
+            try:
+                with open(path, "r", encoding="utf-8") as f:
+                    first_line = f.readline().strip()
+                expected = ",".join(_USAGE_LOG_HEADERS)
+                if first_line and first_line != expected:
+                    os.rename(path, path + ".bak")
+            except OSError:
+                pass
+
         new_file = not os.path.exists(path)
+        in_t = int(input_tokens or 0)
+        out_t = int(output_tokens or 0)
+        think_t = int(reasoning_tokens or 0)
+        tot_t = int(total_tokens or 0) or (in_t + out_t + think_t)
+
         with open(path, "a", newline="", encoding="utf-8") as f:
             w = csv.writer(f)
             if new_file:
                 w.writerow(_USAGE_LOG_HEADERS)
             w.writerow([
                 datetime.now(timezone.utc).isoformat(timespec="seconds"),
-                call_site,
-                provider,
-                model,
-                int(input_tokens or 0),
-                int(output_tokens or 0),
-                int((input_tokens or 0) + (output_tokens or 0)),
+                call_site, provider, model,
+                in_t, out_t, think_t, tot_t,
             ])
-    except Exception as e:  # pragma: no cover — logging failure must not break callers
+
+        if not _usage_log_notified:
+            print(f"[ai_usage] logging to {path}", file=sys.stderr)
+            _usage_log_notified = True
+    except Exception as e:
+        if not _usage_log_notified:
+            print(f"[ai_usage] WARNING: failed to write {path}: {e}",
+                  file=sys.stderr)
+            _usage_log_notified = True
         _log.debug("Failed to write AI usage log: %s", e)
 
 
-def _extract_anthropic_usage(data: dict) -> tuple[int, int]:
+def _extract_anthropic_usage(data: dict) -> tuple[int, int, int, int]:
+    """Return (input, output, reasoning, total) for an Anthropic response.
+
+    Anthropic bills extended-thinking output as regular ``output_tokens``,
+    so reasoning is reported as 0 and total = input + output.
+    """
     usage = data.get("usage") or {}
-    return int(usage.get("input_tokens", 0)), int(usage.get("output_tokens", 0))
+    in_t = int(usage.get("input_tokens", 0))
+    out_t = int(usage.get("output_tokens", 0))
+    return in_t, out_t, 0, in_t + out_t
 
 
-def _extract_google_usage(data: dict) -> tuple[int, int]:
+def _extract_google_usage(data: dict) -> tuple[int, int, int, int]:
+    """Return (input, output, reasoning, total) for a Gemini response.
+
+    Gemini 2.5 reports thinking under ``thoughtsTokenCount`` separately from
+    ``candidatesTokenCount`` (visible output).  Both are billed at the output
+    rate.  ``totalTokenCount`` is the API's authoritative billed total.
+    """
     meta = data.get("usageMetadata") or {}
-    return int(meta.get("promptTokenCount", 0)), int(meta.get("candidatesTokenCount", 0))
+    in_t = int(meta.get("promptTokenCount", 0))
+    out_t = int(meta.get("candidatesTokenCount", 0))
+    think_t = int(meta.get("thoughtsTokenCount", 0))
+    tot_t = int(meta.get("totalTokenCount", 0)) or (in_t + out_t + think_t)
+    return in_t, out_t, think_t, tot_t
 
 
 class ChatClient:
@@ -218,10 +284,11 @@ class ChatClient:
             if block.get("type") == "text":
                 assistant_text += block["text"]
 
-        in_tok, out_tok = _extract_anthropic_usage(data)
+        in_tok, out_tok, think_tok, tot_tok = _extract_anthropic_usage(data)
         _log_token_usage(
             call_site=call_site, provider=self.provider, model=used_model,
             input_tokens=in_tok, output_tokens=out_tok,
+            reasoning_tokens=think_tok, total_tokens=tot_tok,
         )
 
         self.conversation.append({"role": "assistant", "content": assistant_text})
@@ -280,10 +347,11 @@ class ChatClient:
                 if "text" in part:
                     assistant_text += part["text"]
 
-        in_tok, out_tok = _extract_google_usage(data)
+        in_tok, out_tok, think_tok, tot_tok = _extract_google_usage(data)
         _log_token_usage(
             call_site=call_site, provider=self.provider, model=used_model,
             input_tokens=in_tok, output_tokens=out_tok,
+            reasoning_tokens=think_tok, total_tokens=tot_tok,
         )
 
         self.conversation.append({"role": "assistant", "content": assistant_text})
@@ -352,10 +420,11 @@ class ChatClient:
             if block.get("type") == "text":
                 assistant_text += block["text"]
 
-        in_tok, out_tok = _extract_anthropic_usage(data)
+        in_tok, out_tok, think_tok, tot_tok = _extract_anthropic_usage(data)
         _log_token_usage(
             call_site=call_site, provider=self.provider, model=used_model,
             input_tokens=in_tok, output_tokens=out_tok,
+            reasoning_tokens=think_tok, total_tokens=tot_tok,
         )
         return assistant_text
 
@@ -395,10 +464,11 @@ class ChatClient:
                 if "text" in part:
                     assistant_text += part["text"]
 
-        in_tok, out_tok = _extract_google_usage(data)
+        in_tok, out_tok, think_tok, tot_tok = _extract_google_usage(data)
         _log_token_usage(
             call_site=call_site, provider=self.provider, model=used_model,
             input_tokens=in_tok, output_tokens=out_tok,
+            reasoning_tokens=think_tok, total_tokens=tot_tok,
         )
 
         # Check if response was truncated

--- a/src/ai/pine_exporter.py
+++ b/src/ai/pine_exporter.py
@@ -16,8 +16,9 @@ def export_to_pine(chat_client: ChatClient, strategy_source: str) -> str:
         "Translate this Python backtest strategy to TradingView Pine Script v5:\n\n"
         f"```python\n{strategy_source}\n```"
     )
-    # Pine translation is mechanical — flash is enough.
-    pine_model = model_for_tier(chat_client.provider, "light")
+    # Pine translation needs the strategy logic preserved exactly — use the
+    # heavy tier so subtle entry/exit conditions don't get paraphrased away.
+    pine_model = model_for_tier(chat_client.provider, "heavy")
     response = chat_client.one_shot(
         prompt, system_prompt=PINE_EXPORT_SYSTEM_PROMPT,
         call_site="pine_export", model=pine_model,

--- a/src/ai/pine_exporter.py
+++ b/src/ai/pine_exporter.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from .chat_client import ChatClient
+from .chat_client import ChatClient, model_for_tier
 from .prompts import PINE_EXPORT_SYSTEM_PROMPT
 
 
@@ -16,7 +16,12 @@ def export_to_pine(chat_client: ChatClient, strategy_source: str) -> str:
         "Translate this Python backtest strategy to TradingView Pine Script v5:\n\n"
         f"```python\n{strategy_source}\n```"
     )
-    response = chat_client.one_shot(prompt, system_prompt=PINE_EXPORT_SYSTEM_PROMPT)
+    # Pine translation is mechanical — flash is enough.
+    pine_model = model_for_tier(chat_client.provider, "light")
+    response = chat_client.one_shot(
+        prompt, system_prompt=PINE_EXPORT_SYSTEM_PROMPT,
+        call_site="pine_export", model=pine_model,
+    )
 
     # Extract Pine Script code block
     import re

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,14 @@ project_root = Path(__file__).resolve().parent.parent
 if str(project_root) not in sys.path:
     sys.path.insert(0, str(project_root))
 
+
+@pytest.fixture(autouse=True)
+def _isolate_ai_usage_log(tmp_path, monkeypatch):
+    """Redirect the AI usage CSV writer to a per-test tmp path so tests don't
+    pollute the user's real data/ai_usage.csv."""
+    from src.ai import chat_client as _cc
+    monkeypatch.setattr(_cc, "_USAGE_LOG_PATH", str(tmp_path / "ai_usage.csv"))
+
 from src.config.settings import AppConfig, RiskConfig, TradingConfig, StrategyConfig
 from src.execution.position_tracker import PositionTracker
 from src.gateway.event_bus import EventBus

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,8 +15,10 @@ if str(project_root) not in sys.path:
 def _isolate_ai_usage_log(tmp_path, monkeypatch):
     """Redirect the AI usage CSV writer to a per-test tmp path so tests don't
     pollute the user's real data/ai_usage.csv."""
+    monkeypatch.setenv("TAI_AI_USAGE_LOG", str(tmp_path / "ai_usage.csv"))
+    # Reset the one-time stderr notice so each test starts from a clean state.
     from src.ai import chat_client as _cc
-    monkeypatch.setattr(_cc, "_USAGE_LOG_PATH", str(tmp_path / "ai_usage.csv"))
+    monkeypatch.setattr(_cc, "_usage_log_notified", False)
 
 from src.config.settings import AppConfig, RiskConfig, TradingConfig, StrategyConfig
 from src.execution.position_tracker import PositionTracker


### PR DESCRIPTION
## Summary
Daily Google AI API spend was running \$20–30/day. Two compounding causes:
1. `send_message()` re-sends the full conversation history every turn, so the ~150K-token AI Review trade dump permanently inflates every subsequent chat call.
2. Everything ran on `gemini-2.5-pro` with a 64K output cap, even for tiny chat replies and recaps.

This PR ships six targeted fixes:

- **Trim trade dump after review.** Single-shot and chunked AI Review now overwrite each trade-dump user turn with a compact stub (`[trade review payload — N trades, trimmed to save tokens]`) right after the API call returns. The next chat turn replays a few KB instead of ~150K tokens.
- **Token usage logging.** Every `send_message()` / `one_shot()` appends a row to `data/ai_usage.csv` (`timestamp, call_site, provider, model, input_tokens, output_tokens, total_tokens`). Headers are auto-written, write failures are swallowed, tests are isolated to a tmp path so they don't pollute the per-machine log.
- **Model tier per call site.** New `model_for_tier(provider, "light"|"heavy")` helper picks `gemini-2.5-flash` for chat / recap / pine_export, keeps `gemini-2.5-pro` for codegen and trade review. Anthropic users keep whatever model they configured.
- **Conversation size guard.** `send_message()` checks total chars before each call; if > 200K it drops oldest middle messages (keeps first + recent tail) and logs a warning.
- **Code-gen output cap.** `_CODE_GEN_MAX_TOKENS` 65536 → 16384. Strategies are <300 lines; the old cap was wasteful headroom.
- **Recap size gate.** New `recap_token_gate` setting (default 30); when a loaded session already has more messages than the gate, the post-load recap is skipped — a recap that re-sends the full history just to summarize it is exactly the call we want to avoid.

## Test plan
- [x] `python -m pytest tests/ -x -q` — 923 passed, 5 skipped.
- [x] Test isolation: confirmed `data/ai_usage.csv` is not created or modified by test runs (autouse fixture redirects to `tmp_path`).
- [x] Confirmed `data/` is in `.gitignore` so per-machine usage logs never get committed.
- [ ] Manual: run AI Review on a real backtest, confirm `data/ai_usage.csv` shows the `trade_review` row, then send a follow-up chat message and verify the trade-dump turn was replaced with the stub (inspect saved chat session JSON).
- [ ] Manual: load a 40-message saved chat and verify the recap is skipped with the gate message rather than firing.
- [ ] Manual (Gemini provider): tail `data/ai_usage.csv` and confirm chat / recap rows show `gemini-2.5-flash`, codegen / trade review rows show `gemini-2.5-pro`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)