### PR TITLE
fix(tick_watchdog): no false-positive reconnect/loop at session boundary (#66)

### DIFF
--- a/run_backtest.py
+++ b/run_backtest.py
@@ -3851,6 +3851,9 @@ class BacktestApp:
             self._live_tick_active = True
             self._tick_watchdog.on_tick()
             self._tick_watchdog.active = True
+            # Tell the watchdog the order symbol so it knows about the
+            # 13:30 settlement-day close for front-month contracts.
+            self._tick_watchdog.order_symbol = resolve_order_symbol(symbol)
             self._live_log_msg(f"已訂閱 Tick subscription active for {symbol}", "status")
             _log(f"即時報價訂閱成功 Tick subscription OK: {symbol}, result={result}")
         except Exception as e:

--- a/run_backtest.py
+++ b/run_backtest.py
@@ -4027,6 +4027,11 @@ class BacktestApp:
             self._live_log_msg(
                 "新盤重新訂閱 New session — re-subscribing ticks", "status")
             self._resubscribe_ticks()
+            # Advance last_tick_time so the trigger condition clears.
+            # Without this, every 30s check re-fires session_resubscribe
+            # forever because last_tick_time still corresponds to the
+            # prior closed-market period (issue #66).
+            self._tick_watchdog.on_session_resubscribe()
 
         elif action == "reconnect":
             _log(f"Tick watchdog: no ticks for {mins}m, forcing full reconnect")

--- a/src/live/tick_watchdog.py
+++ b/src/live/tick_watchdog.py
@@ -12,6 +12,38 @@ from datetime import datetime
 from .live_runner import is_market_open, minutes_until_session_close, _TZ_TAIPEI
 
 
+def _crossed_session_gap(last_ts: float, now_ts: float) -> bool:
+    """Return True if a market-closed period exists between last_ts and now_ts.
+
+    Used to distinguish session boundary crossings from same-session
+    zombie scenarios.  Both:
+
+      * last tick during closed market (e.g. subscription auto-tick at 14:50
+        during the 13:45-15:00 gap), and
+      * last tick during prior session (e.g. last AM tick at 13:28, check at
+        15:00 PM open — bot 0422 case from issue #66)
+
+    are session-boundary scenarios that warrant a soft resubscribe rather
+    than a 10-minute-elapsed reconnect.
+    """
+    if now_ts <= last_ts:
+        return False
+    last_dt = datetime.fromtimestamp(last_ts, tz=_TZ_TAIPEI)
+    # If last tick was itself during closed market, definitely a gap
+    if not is_market_open(last_dt):
+        return True
+    # Walk the interval in 5-min steps looking for a closed sample.
+    # Real session gaps are >= 75 min (13:45-15:00) or >= 225 min (05:00-08:45),
+    # so 5-min stride catches them with tens of iterations max.
+    step = 300
+    t = last_ts + step
+    while t < now_ts:
+        if not is_market_open(datetime.fromtimestamp(t, tz=_TZ_TAIPEI)):
+            return True
+        t += step
+    return False
+
+
 class TickWatchdog:
     """Monitors tick freshness and decides when to resubscribe or reconnect.
 
@@ -63,13 +95,13 @@ class TickWatchdog:
         """Call after issuing a session-transition resubscribe.
 
         Unlike on_resubscribe(), this DOES advance last_tick_time to
-        wall-clock now.  Rationale: the session_resubscribe trigger fires
-        when last_tick_time was set during a wall-clock closed-market
-        period (e.g. a subscription-time auto-tick at 14:50, fired during
-        the 13:45-15:00 gap).  Without advancing last_tick_time, every
-        subsequent check() at 30s cadence keeps seeing the same
-        "last tick was during closed market" condition and re-fires
-        session_resubscribe forever (issue #66).
+        wall-clock now.  Rationale: the session_resubscribe trigger
+        fires when a closed-market gap exists between last_tick_time
+        and now — e.g. a subscription-time auto-tick at 14:50 during
+        the 13:45-15:00 gap, OR a normal last AM tick at 13:28 with
+        check at 15:00 PM open.  In either case the elapsed reading
+        across the gap is meaningless and the trigger condition would
+        keep firing on every 30s check.
 
         Advancing last_tick_time restarts the normal staleness clock.
         If ticks really aren't arriving (zombie session), the regular
@@ -122,13 +154,27 @@ class TickWatchdog:
         if now < self.grace_until:
             return None
 
-        # Session transition: last tick was during closed market.
-        # The old subscription is stale — resubscribe immediately.
-        last_dt = datetime.fromtimestamp(self.last_tick_time, tz=_TZ_TAIPEI)
-        if not is_market_open(last_dt):
-            return "session_resubscribe"
+        # Session boundary: a closed-market period exists between last
+        # tick and now (last tick during closed gap, or last tick in a
+        # prior session).  Prefer a soft resubscribe over a heavy
+        # reconnect — the 90+ minute elapsed reading is a measurement
+        # artifact of the gap, not a real zombie session.
+        #
+        # RESUBSCRIBE_COOLDOWN prevents the 30s-check loop; the GUI
+        # handler should also call on_session_resubscribe() to advance
+        # last_tick_time so subsequent checks see a fresh clock.  If
+        # ticks still don't arrive, normal warn → resubscribe →
+        # reconnect escalation takes over within minutes.
+        if _crossed_session_gap(self.last_tick_time, now):
+            in_cooldown = (self.last_resubscribe
+                           and (now - self.last_resubscribe) < self.RESUBSCRIBE_COOLDOWN)
+            if not in_cooldown:
+                return "session_resubscribe"
+            # In cooldown: stay quiet rather than escalating to reconnect
+            # on a stale elapsed reading that spans the closed gap.
+            return None
 
-        # Normal staleness checks
+        # Normal staleness checks (same-session zombie)
         elapsed = now - self.last_tick_time
         if elapsed <= self.WARN_TIMEOUT:
             return None

--- a/src/live/tick_watchdog.py
+++ b/src/live/tick_watchdog.py
@@ -71,6 +71,11 @@ class TickWatchdog:
         self.last_tick_time: float = 0.0
         self.grace_until: float = 0.0   # suppress warnings until this time
         self.last_resubscribe: float = 0.0  # for cooldown
+        # Order symbol (e.g. "TM0000") — used so minutes_until_session_close
+        # applies the settlement-day 13:30 close for front-month contracts.
+        # Without this, the watchdog uses the default 13:45 close and warns
+        # between 13:30 and 13:35 on settlement day (issue #66).
+        self.order_symbol: str | None = None
 
     def on_tick(self) -> None:
         """Call when a real tick is received (live or history).
@@ -122,6 +127,7 @@ class TickWatchdog:
         self.last_tick_time = 0.0
         self.grace_until = 0.0
         self.last_resubscribe = 0.0
+        self.order_symbol = None
 
     def check(self, now: float | None = None) -> str | None:
         """Check tick health and return the action needed.
@@ -142,9 +148,18 @@ class TickWatchdog:
         if not is_market_open():
             return None
 
-        # Suppress near session close — thin volume is normal
-        mins_left = minutes_until_session_close()
-        if mins_left is not None and mins_left <= self.NEAR_CLOSE_SUPPRESS:
+        # Settlement-day awareness: for front-month contracts, the AM
+        # session closes at 13:30 (not 13:45).  minutes_until_session_close
+        # returns None when we're past the effective close for this
+        # order_symbol even though the global is_market_open still says
+        # True until 13:45.  Treat that window as closed — otherwise the
+        # bot warns every 30s between 13:30 and 13:35 on settlement day
+        # (issue #66).  Near-close suppression also uses the early close
+        # so we don't warn during the last 10 min of real trading.
+        mins_left = minutes_until_session_close(self.order_symbol)
+        if mins_left is None:
+            return None
+        if mins_left <= self.NEAR_CLOSE_SUPPRESS:
             return None
 
         if now is None:

--- a/src/live/tick_watchdog.py
+++ b/src/live/tick_watchdog.py
@@ -59,6 +59,27 @@ class TickWatchdog:
         """
         self.last_resubscribe = time.time()
 
+    def on_session_resubscribe(self) -> None:
+        """Call after issuing a session-transition resubscribe.
+
+        Unlike on_resubscribe(), this DOES advance last_tick_time to
+        wall-clock now.  Rationale: the session_resubscribe trigger fires
+        when last_tick_time was set during a wall-clock closed-market
+        period (e.g. a subscription-time auto-tick at 14:50, fired during
+        the 13:45-15:00 gap).  Without advancing last_tick_time, every
+        subsequent check() at 30s cadence keeps seeing the same
+        "last tick was during closed market" condition and re-fires
+        session_resubscribe forever (issue #66).
+
+        Advancing last_tick_time restarts the normal staleness clock.
+        If ticks really aren't arriving (zombie session), the regular
+        warn→resubscribe→reconnect escalation kicks in after WARN_TIMEOUT.
+        Real ticks will reset state via on_tick() as usual.
+        """
+        now = time.time()
+        self.last_tick_time = now
+        self.last_resubscribe = now
+
     def set_grace(self, seconds: int = 30) -> None:
         """Set a grace period after reconnect/resubscribe."""
         self.grace_until = time.time() + seconds

--- a/src/market_data/holidays.py
+++ b/src/market_data/holidays.py
@@ -113,8 +113,26 @@ def is_front_month_contract(order_symbol: str, d: date | datetime | None = None)
 
     Back-month contracts (May, June, ...) keep trading until 13:45 even
     on settlement day; only the front-month is force-settled at 13:30.
+
+    Also recognizes the static "near-month" placeholder codes used by
+    Capital API continuous-quote symbols (TX00 → "TXFD0", MTX00 →
+    "MTXFD0", TMF00 → "TM0000").  These don't match the standard
+    {letter}{digit} suffix but the broker auto-routes them to the
+    current front-month contract, so for settlement-day purposes they
+    behave as front-month.
     """
-    if not order_symbol or len(order_symbol) < 2:
+    if not order_symbol:
+        return False
+    # Near-month quote-symbol placeholders (issue #66): without this
+    # branch, is_front_month_contract("TM0000") returns False on
+    # settlement day and minutes_until_session_close keeps using 13:45
+    # instead of the actual 13:30 settlement close → false-positive
+    # watchdog warnings between 13:30 and 13:45.
+    from .kline_config import SYMBOL_CONFIG
+    for cfg in SYMBOL_CONFIG.values():
+        if cfg.get("near_month") and cfg.get("order_symbol") == order_symbol:
+            return True
+    if len(order_symbol) < 2:
         return False
     if d is None:
         from src.live.live_runner import _taipei_now

--- a/src/market_data/kline_config.py
+++ b/src/market_data/kline_config.py
@@ -51,13 +51,16 @@ LIVE_CHART_TIMEFRAMES = {
 
 SYMBOL_CONFIG = {
     "TX00": {"prefix": "TXF1", "tv": "TXF1!", "pv": 200, "tick_divisor": 100,
-             "taifex_id": "TX", "order_symbol": "TXFD0", "init_margin": 322000},
+             "taifex_id": "TX", "order_symbol": "TXFD0", "init_margin": 322000,
+             "near_month": True},
     "MTX00": {"prefix": "TMF1", "tv": "TMF1!", "pv": 50, "tick_divisor": 100,
               "taifex_id": "MTX", "order_symbol": "MTXFD0",
-              "kline_symbol": "TX00", "tick_symbol": "TX00", "init_margin": 80500},
+              "kline_symbol": "TX00", "tick_symbol": "TX00", "init_margin": 80500,
+              "near_month": True},
     "TMF00": {"prefix": "IMF1", "tv": "IMF1!", "pv": 10, "tick_divisor": 100,
               "taifex_id": "TMF", "order_symbol": "TM0000",
-              "kline_symbol": "TX00", "tick_symbol": "TX00", "init_margin": 16100},
+              "kline_symbol": "TX00", "tick_symbol": "TX00", "init_margin": 16100,
+              "near_month": True},
 }
 
 _MONTH_CODES = "ABCDEFGHIJKL"  # A=Jan .. L=Dec

--- a/tests/test_settlement_day.py
+++ b/tests/test_settlement_day.py
@@ -114,6 +114,19 @@ class TestIsFrontMonthContract:
         assert is_front_month_contract("", d) is False
         assert is_front_month_contract("X", d) is False
 
+    def test_near_month_placeholder_symbols_are_front_month(self):
+        """Issue #66: continuous-quote symbols TX00/MTX00/TMF00 use
+        static placeholder order_symbol values that don't match the
+        {letter}{digit} suffix pattern. Without recognizing them,
+        settlement-day detection fails for these (very common) symbols."""
+        d = date(2026, 5, 20)  # settlement day for May
+        # Capital API auto-routes these to current front-month
+        assert is_front_month_contract("TM0000", d) is True   # TMF00
+        assert is_front_month_contract("TXFD0", d) is True    # TX00
+        assert is_front_month_contract("MTXFD0", d) is True   # MTX00
+        # Real back-month code on the same date — not front-month
+        assert is_front_month_contract("TXFF6", d) is False   # June 2026
+
     def test_accepts_datetime(self):
         dt = datetime(2026, 4, 15, 9, 0, tzinfo=_TPE)
         assert is_front_month_contract("TXFD6", dt) is True

--- a/tests/test_tick_watchdog.py
+++ b/tests/test_tick_watchdog.py
@@ -165,6 +165,70 @@ class TestWeekendTransition:
         assert action == "session_resubscribe"
 
 
+class TestSettlementDayClose:
+    """Issue #66 part 2: on settlement day (3rd Wed), front-month
+    contracts force-settle at 13:30. Without symbol-aware close
+    handling, the watchdog uses the default 13:45 and warns/escalates
+    between 13:30 and 13:45 when ticks correctly stop at 13:30.
+    """
+
+    def test_settlement_no_warning_between_1330_and_1345(self):
+        """Last tick at 13:28 (just before settlement close), check at
+        13:32 with order_symbol=TM0000 (TMF00 front-month) → no warn.
+
+        With the bug: default 13:45 close, mins_left=13 (not near close),
+        elapsed=4min > WARN_TIMEOUT → "warn".
+        """
+        wd = TickWatchdog()
+        wd.active = True
+        wd.order_symbol = "TM0000"  # front-month placeholder for TMF00
+
+        last_tick = _taipei_dt(2026, 5, 20, 13, 28)  # settlement day
+        wd.last_tick_time = _ts(last_tick)
+
+        check_dt = _taipei_dt(2026, 5, 20, 13, 32)
+        with _patch_now(check_dt):
+            action = wd.check(now=_ts(check_dt))
+        assert action is None  # past effective close, no warning
+
+    def test_settlement_no_warning_at_1334(self):
+        wd = TickWatchdog()
+        wd.active = True
+        wd.order_symbol = "TM0000"
+        last_tick = _taipei_dt(2026, 5, 20, 13, 28)
+        wd.last_tick_time = _ts(last_tick)
+        check_dt = _taipei_dt(2026, 5, 20, 13, 34)
+        with _patch_now(check_dt):
+            assert wd.check(now=_ts(check_dt)) is None
+
+    def test_non_settlement_day_still_warns_after_1330(self):
+        """On a non-settlement day, 13:30-13:45 is regular trading,
+        so a stale tick from 13:29 SHOULD trigger warn at 13:32."""
+        wd = TickWatchdog()
+        wd.active = True
+        wd.order_symbol = "TM0000"
+        # 2026-05-19 is Tuesday, NOT settlement day
+        last_tick = _taipei_dt(2026, 5, 19, 13, 29)  # 3 min before check
+        wd.last_tick_time = _ts(last_tick)
+        check_dt = _taipei_dt(2026, 5, 19, 13, 32)
+        with _patch_now(check_dt):
+            action = wd.check(now=_ts(check_dt))
+        assert action == "warn"
+
+    def test_settlement_back_month_uses_1345_close(self):
+        """Back-month contracts (e.g. June TXFF6) close at 13:45 even
+        on settlement day — the early close only applies to front-month."""
+        wd = TickWatchdog()
+        wd.active = True
+        wd.order_symbol = "TXFF6"  # June 2026, back-month on May settlement day
+        last_tick = _taipei_dt(2026, 5, 20, 13, 29)
+        wd.last_tick_time = _ts(last_tick)
+        check_dt = _taipei_dt(2026, 5, 20, 13, 32)
+        with _patch_now(check_dt):
+            action = wd.check(now=_ts(check_dt))
+        assert action == "warn"
+
+
 class TestBot0422FalseReconnect:
     """Issue #66: bot 0422 case.
 

--- a/tests/test_tick_watchdog.py
+++ b/tests/test_tick_watchdog.py
@@ -54,8 +54,15 @@ class TestSessionTransitionAMtoPM:
             action = wd.check(now=_ts(check_dt))
         assert action == "session_resubscribe"
 
-    def test_last_tick_at_am_close_triggers_reconnect(self):
-        """Tick at 13:44 (AM open), check at 15:01 → reconnect (>10min elapsed)."""
+    def test_last_tick_at_am_close_triggers_session_resubscribe(self):
+        """Tick at 13:44 (AM open), check at 15:01 → session_resubscribe.
+
+        Issue #66 (bot 0422 case): even when last tick was in the prior
+        session (not in the gap itself), the elapsed measurement spans the
+        13:45-15:00 closed gap, so the 77-min reading is a measurement
+        artifact. Prefer a soft resubscribe over a heavy reconnect; if
+        ticks really don't arrive, normal escalation kicks in afterward.
+        """
         wd = TickWatchdog()
         wd.active = True
 
@@ -63,18 +70,23 @@ class TestSessionTransitionAMtoPM:
         am_dt = _taipei_dt(2026, 3, 17, 13, 44)
         wd.last_tick_time = _ts(am_dt)
 
-        # Check at 15:01 — elapsed ~77min, last tick was during open market
+        # Check at 15:01 — elapsed ~77min, but spans the closed gap
         check_dt = _taipei_dt(2026, 3, 17, 15, 1)
         with _patch_now(check_dt):
             action = wd.check(now=_ts(check_dt))
-        assert action == "reconnect"  # >10min elapsed
+        assert action == "session_resubscribe"
 
 
 class TestSessionTransitionPMtoAM:
     """PM session closes 05:00, AM opens 08:45 next day."""
 
-    def test_last_tick_before_close_triggers_reconnect(self):
-        """Tick at 04:59 (PM open), check at 08:46 → reconnect (>3h elapsed)."""
+    def test_last_tick_before_close_triggers_session_resubscribe(self):
+        """Tick at 04:59 (PM open), check at 08:46 → session_resubscribe.
+
+        Last tick was just before the 05:00 night close; check at next
+        AM open. Elapsed (~3h47m) spans the 05:00-08:45 closed gap, so
+        it's a session boundary not a same-session zombie.
+        """
         wd = TickWatchdog()
         wd.active = True
 
@@ -82,11 +94,11 @@ class TestSessionTransitionPMtoAM:
         pm_dt = _taipei_dt(2026, 3, 18, 4, 59)
         wd.last_tick_time = _ts(pm_dt)
 
-        # Check at 08:46 — elapsed ~3h47m, last tick during open market
+        # Check at 08:46 — gap spans 05:00-08:45 closed period
         check_dt = _taipei_dt(2026, 3, 18, 8, 46)
         with _patch_now(check_dt):
             action = wd.check(now=_ts(check_dt))
-        assert action == "reconnect"
+        assert action == "session_resubscribe"
 
     def test_last_tick_at_close_triggers_session_resubscribe(self):
         """Tick at 05:01 (market closed), check at 08:46 → session_resubscribe."""
@@ -107,33 +119,36 @@ class TestWeekendTransition:
     """Friday PM → Saturday 05:00 close → Monday AM 08:45 open."""
 
     def test_friday_night_tick_monday_morning(self):
-        """Last tick Friday 23:00, check Monday 08:46 → reconnect."""
+        """Last tick Friday 23:00, check Monday 08:46 → session_resubscribe.
+
+        Multi-day gap is still a session boundary — start with the soft
+        action; if the COM session is actually dead, the resubscribe will
+        fail (returning an error from RequestTicks) or no ticks will
+        arrive, and the normal escalation reaches reconnect within minutes.
+        """
         wd = TickWatchdog()
         wd.active = True
 
-        # Friday night tick (market open)
         fri_dt = _taipei_dt(2026, 3, 20, 23, 0)  # Friday
         wd.last_tick_time = _ts(fri_dt)
 
-        # Monday morning (AM open)
         mon_dt = _taipei_dt(2026, 3, 23, 8, 46)  # Monday
         with _patch_now(mon_dt):
             action = wd.check(now=_ts(mon_dt))
-        assert action == "reconnect"  # >2 days elapsed, last tick was open market
+        assert action == "session_resubscribe"
 
     def test_saturday_morning_tick_monday(self):
         """Last tick Saturday 04:59 (Fri night carryover), check Monday 08:46."""
         wd = TickWatchdog()
         wd.active = True
 
-        # Saturday 04:59 (market still open from Friday night)
         sat_dt = _taipei_dt(2026, 3, 21, 4, 59)  # Saturday
         wd.last_tick_time = _ts(sat_dt)
 
         mon_dt = _taipei_dt(2026, 3, 23, 8, 46)
         with _patch_now(mon_dt):
             action = wd.check(now=_ts(mon_dt))
-        assert action == "reconnect"
+        assert action == "session_resubscribe"
 
     def test_saturday_after_close_monday(self):
         """Last tick Saturday 06:00 (closed), check Monday 08:46 → session_resubscribe."""
@@ -148,6 +163,66 @@ class TestWeekendTransition:
         with _patch_now(mon_dt):
             action = wd.check(now=_ts(mon_dt))
         assert action == "session_resubscribe"
+
+
+class TestBot0422FalseReconnect:
+    """Issue #66: bot 0422 case.
+
+    Last real tick at 13:28 (AM session), no more ticks (settlement day or
+    cash-market early close), watchdog warns 13:32-13:34, suppressed
+    13:35-13:45, market closes 13:45, reopens 15:00 → watchdog measures
+    90 min elapsed and force-reconnects.
+
+    The 90-min reading is a measurement artifact across the closed gap,
+    not a zombie session. The fix should treat this as a session boundary
+    (soft resubscribe), not escalate straight to reconnect.
+    """
+
+    def test_first_pm_check_resubscribes_not_reconnects(self):
+        """At 15:00:22 first check after PM open, action must be
+        session_resubscribe (not the buggy 90m force-reconnect)."""
+        wd = TickWatchdog()
+        wd.active = True
+
+        last_tick = _taipei_dt(2026, 5, 20, 13, 28)
+        wd.last_tick_time = _ts(last_tick)
+
+        check_dt = _taipei_dt(2026, 5, 20, 15, 0)
+        with _patch_now(check_dt):
+            action = wd.check(now=_ts(check_dt) + 22)  # 15:00:22
+        assert action == "session_resubscribe"
+
+    def test_no_reconnect_loop_after_handler(self):
+        """After handler runs on_session_resubscribe, subsequent checks
+        must NOT keep firing — neither session_resubscribe nor reconnect."""
+        wd = TickWatchdog()
+        wd.active = True
+
+        last_tick = _taipei_dt(2026, 5, 20, 13, 28)
+        wd.last_tick_time = _ts(last_tick)
+
+        check_dt = _taipei_dt(2026, 5, 20, 15, 0)
+        first = _ts(check_dt) + 22
+        with _patch_now(check_dt):
+            assert wd.check(now=first) == "session_resubscribe"
+
+        # Handler runs at 15:00:22
+        with patch("src.live.tick_watchdog.time.time", return_value=first):
+            wd.set_grace(30)
+            wd.on_session_resubscribe()
+
+        # 30s later, grace expired — must be quiet, NOT reconnect
+        second = first + 30
+        second_dt = datetime.fromtimestamp(second, tz=_TZ_TAIPEI)
+        with _patch_now(second_dt):
+            action2 = wd.check(now=second)
+        assert action2 is None
+
+        # Another minute — still quiet
+        third = first + 90
+        third_dt = datetime.fromtimestamp(third, tz=_TZ_TAIPEI)
+        with _patch_now(third_dt):
+            assert wd.check(now=third) is None
 
 
 class TestNormalStaleness:

--- a/tests/test_tick_watchdog.py
+++ b/tests/test_tick_watchdog.py
@@ -352,6 +352,129 @@ class TestResubscribeCooldown:
             action = wd.check(now=_ts(fake_now_dt))
         assert action == "reconnect"
 
+    def test_on_session_resubscribe_advances_last_tick_time(self):
+        """on_session_resubscribe must reset last_tick_time so the
+        session_resubscribe trigger condition clears (issue #66)."""
+        wd = TickWatchdog()
+        # last tick from a closed-market wall-clock time
+        gap_dt = _taipei_dt(2026, 5, 19, 14, 50)  # AM/PM gap
+        wd.last_tick_time = _ts(gap_dt)
+        before_resub = wd.last_tick_time
+
+        wd.on_session_resubscribe()
+
+        assert wd.last_tick_time > before_resub
+        assert wd.last_resubscribe > 0
+        # last_tick_time should be approximately wall-clock now
+        assert abs(wd.last_tick_time - time.time()) < 1.0
+
+    def test_session_resubscribe_does_not_loop_after_handler_call(self):
+        """Issue #66 regression: subscribe during 13:45-15:00 gap, then
+        session_resubscribe fires once at 15:00. After the handler runs
+        on_session_resubscribe(), subsequent checks must NOT keep firing
+        session_resubscribe at every 30s watchdog tick."""
+        wd = TickWatchdog()
+        wd.active = True
+
+        # Subscription at 14:47:50 sets last_tick_time during the gap
+        sub_dt = _taipei_dt(2026, 5, 19, 14, 47)
+        wd.last_tick_time = _ts(sub_dt)
+
+        # First check at 15:00:24 — fires session_resubscribe
+        check1 = _taipei_dt(2026, 5, 19, 15, 0)
+        with _patch_now(check1):
+            action1 = wd.check(now=_ts(check1) + 24)
+        assert action1 == "session_resubscribe"
+
+        # Handler runs: _resubscribe_ticks (sets grace=30) then
+        # on_session_resubscribe (advances last_tick_time to now)
+        with patch("src.live.tick_watchdog.time.time",
+                   return_value=_ts(check1) + 24):
+            wd.set_grace(30)
+            wd.on_session_resubscribe()
+
+        # Next check 30s later — grace expired, but last_tick_time is now
+        # fresh, so no session_resubscribe loop
+        check2 = _ts(check1) + 54
+        check2_dt = datetime.fromtimestamp(check2, tz=_TZ_TAIPEI)
+        with _patch_now(check2_dt):
+            action2 = wd.check(now=check2)
+        assert action2 is None  # Loop is broken
+
+        # Check several more cycles to confirm no loop
+        for offset in (84, 114, 144):
+            t = _ts(check1) + offset
+            t_dt = datetime.fromtimestamp(t, tz=_TZ_TAIPEI)
+            with _patch_now(t_dt):
+                assert wd.check(now=t) is None
+
+    def test_session_resubscribe_zombie_escalates_to_warn_then_reconnect(self):
+        """If after a session_resubscribe ticks STILL don't arrive (true
+        zombie session), the watchdog must escalate via normal staleness
+        ladder rather than silently swallowing the problem."""
+        wd = TickWatchdog()
+        wd.active = True
+
+        # Subscription during gap → session_resubscribe at PM open
+        sub_dt = _taipei_dt(2026, 5, 19, 14, 47)
+        wd.last_tick_time = _ts(sub_dt)
+        check1 = _taipei_dt(2026, 5, 19, 15, 0)
+        with _patch_now(check1):
+            assert wd.check(now=_ts(check1) + 24) == "session_resubscribe"
+
+        # Handler does on_session_resubscribe at 15:00:24
+        handler_t = _ts(check1) + 24
+        with patch("src.live.tick_watchdog.time.time",
+                   return_value=handler_t):
+            wd.on_session_resubscribe()
+            # No grace this time — testing escalation purely on elapsed
+            wd.grace_until = 0
+
+        # 3 min later — should warn (no ticks ever arrived)
+        t_warn = handler_t + 150  # > WARN_TIMEOUT (120)
+        t_warn_dt = datetime.fromtimestamp(t_warn, tz=_TZ_TAIPEI)
+        with _patch_now(t_warn_dt):
+            assert wd.check(now=t_warn) == "warn"
+
+        # 11 min later — should reconnect
+        t_reconnect = handler_t + 700  # > RECONNECT_TIMEOUT (600)
+        t_reconnect_dt = datetime.fromtimestamp(t_reconnect, tz=_TZ_TAIPEI)
+        with _patch_now(t_reconnect_dt):
+            assert wd.check(now=t_reconnect) == "reconnect"
+
+    def test_session_resubscribe_recovers_when_real_ticks_arrive(self):
+        """After session_resubscribe, if real ticks do arrive, the
+        watchdog should remain quiet — on_tick() resets everything."""
+        wd = TickWatchdog()
+        wd.active = True
+
+        sub_dt = _taipei_dt(2026, 5, 19, 14, 47)
+        wd.last_tick_time = _ts(sub_dt)
+        check1 = _taipei_dt(2026, 5, 19, 15, 0)
+        with _patch_now(check1):
+            assert wd.check(now=_ts(check1) + 24) == "session_resubscribe"
+
+        handler_t = _ts(check1) + 24
+        with patch("src.live.tick_watchdog.time.time",
+                   return_value=handler_t):
+            wd.on_session_resubscribe()
+
+        # A real tick at 15:00:30
+        tick_t = handler_t + 6
+        with patch("src.live.tick_watchdog.time.time",
+                   return_value=tick_t):
+            wd.on_tick()
+        assert wd.last_resubscribe == 0.0  # cleared by on_tick
+
+        # Subsequent checks are quiet
+        for offset in (30, 60, 90, 120):
+            t = tick_t + offset
+            t_dt = datetime.fromtimestamp(t, tz=_TZ_TAIPEI)
+            with _patch_now(t_dt):
+                # last_tick_time = tick_t, elapsed = offset
+                # All under WARN_TIMEOUT
+                assert wd.check(now=t) is None
+
     def test_zombie_session_eventually_escalates_to_reconnect(self):
         """End-to-end zombie scenario: tick stops at T=0, resubscribes at
         T=300 (fails silently), by T=700 we should reconnect."""


### PR DESCRIPTION
## Summary
Closes #66. Three commits addressing distinct but related failure modes the watchdog showed on TMF00 (and any TX00/MTX00 bot) at session boundaries and on settlement day.

## Root cause #3 — settlement-day 13:30 close not applied to TMF00 (this commit)
On the user's bot log from settlement day (2026-05-20):
```
[13:29:00] 1m bar: 13:28 O=40078 C=40078 V=141
[13:32:01] 警告 No ticks for 2m
[13:33:02] 警告 No ticks for 3m
[13:34:03] 警告 No ticks for 4m
[13:43:26] daily report
[15:00:22] 強制重連 Force reconnect — no ticks for 90m
```
TM0000 (TMF00's front-month) settles at 13:30 on the 3rd Wednesday. Ticks correctly stopped at 13:28. But:

- `SYMBOL_CONFIG[\"TMF00\"][\"order_symbol\"] == \"TM0000\"` is a Capital API static placeholder
- `is_front_month_contract(\"TM0000\")` parsed the last two chars expecting `{letter}{digit}` (\"E6\" for May 2026), got `\"00\"` → **always returned False**
- `_am_close_minutes` therefore returned `825` (13:45), not `810` (13:30)
- `TickWatchdog.check()` never passed `order_symbol` to `minutes_until_session_close` anyway

So warnings fired 13:32-13:34 (mins_left=13-11, outside 10-min suppression), then the 90-min force-reconnect was triggered by the elapsed reading across the 13:30-15:00 gap.

### Fix
1. `SYMBOL_CONFIG`: tag TX00/MTX00/TMF00 with `near_month: True` — these continuous quote symbols always track the front-month contract regardless of the static order_symbol value.
2. `is_front_month_contract`: reverse-lookup `near_month` placeholders in SYMBOL_CONFIG before the suffix-pattern check. `\"TM0000\"`, `\"TXFD0\"`, `\"MTXFD0\"` all return True on any settlement day. The standard `{letter}{digit}` pattern check for real contract codes (TXFE6 etc.) is preserved.
3. `TickWatchdog`: new `order_symbol` attribute, passed to `minutes_until_session_close`. Treat `mins_left is None` during open market as \"past effective close\" — suppress all alerts so the 13:30-13:45 window is quiet on settlement day.
4. GUI sets `self._tick_watchdog.order_symbol = resolve_order_symbol(symbol)` right after the tick subscription succeeds.

## All three commits in this PR
| # | What | When it fires |
|---|------|---------------|
| 1 | `on_session_resubscribe()` advances `last_tick_time` after a session-transition resubscribe | Loop when subscribe-time auto-tick lands inside the closed gap |
| 2 | `_crossed_session_gap` detects ANY closed period between last tick and now → soft resubscribe instead of false reconnect | Last tick in prior session, check at next open (false 90m reconnect) |
| 3 | Settlement-day 13:30 close applied to TMF00/TX00/MTX00 via `near_month` flag + `TickWatchdog.order_symbol` | Warnings 13:32-13:34 + force reconnect cascade on settlement day |

## Test plan
- [x] `TestSettlementDayClose` (new) — settlement-day 13:30 quiet for TMF00, still warns on non-settlement days, back-month TXFF6 still uses 13:45
- [x] `TestIsFrontMonthContract::test_near_month_placeholder_symbols_are_front_month` — TM0000/TXFD0/MTXFD0 recognized
- [x] `TestBot0422FalseReconnect` — exact reproducer for symptom 2
- [x] `TestResubscribeCooldown` — zombie sessions still escalate to reconnect (unchanged)
- [x] All 961 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)