### PR TITLE
fix(watchdog): settlement-day 13:30 close for TMF00/MTX00/TX00 (#66)

### DIFF
--- a/run_backtest.py
+++ b/run_backtest.py
@@ -3851,6 +3851,9 @@ class BacktestApp:
             self._live_tick_active = True
             self._tick_watchdog.on_tick()
             self._tick_watchdog.active = True
+            # Tell the watchdog the order symbol so it knows about the
+            # 13:30 settlement-day close for front-month contracts.
+            self._tick_watchdog.order_symbol = resolve_order_symbol(symbol)
             self._live_log_msg(f"已訂閱 Tick subscription active for {symbol}", "status")
             _log(f"即時報價訂閱成功 Tick subscription OK: {symbol}, result={result}")
         except Exception as e:

--- a/src/live/tick_watchdog.py
+++ b/src/live/tick_watchdog.py
@@ -39,6 +39,11 @@ class TickWatchdog:
         self.last_tick_time: float = 0.0
         self.grace_until: float = 0.0   # suppress warnings until this time
         self.last_resubscribe: float = 0.0  # for cooldown
+        # Order symbol (e.g. "TM0000") — used so minutes_until_session_close
+        # applies the settlement-day 13:30 close for front-month contracts.
+        # Without this, the watchdog uses the default 13:45 close and warns
+        # between 13:30 and 13:35 on settlement day (issue #66).
+        self.order_symbol: str | None = None
 
     def on_tick(self) -> None:
         """Call when a real tick is received (live or history).
@@ -69,6 +74,7 @@ class TickWatchdog:
         self.last_tick_time = 0.0
         self.grace_until = 0.0
         self.last_resubscribe = 0.0
+        self.order_symbol = None
 
     def check(self, now: float | None = None) -> str | None:
         """Check tick health and return the action needed.
@@ -89,9 +95,18 @@ class TickWatchdog:
         if not is_market_open():
             return None
 
-        # Suppress near session close — thin volume is normal
-        mins_left = minutes_until_session_close()
-        if mins_left is not None and mins_left <= self.NEAR_CLOSE_SUPPRESS:
+        # Settlement-day awareness: for front-month contracts, the AM
+        # session closes at 13:30 (not 13:45).  minutes_until_session_close
+        # returns None when we're past the effective close for this
+        # order_symbol even though the global is_market_open still says
+        # True until 13:45.  Treat that window as closed — otherwise the
+        # bot warns every 30s between 13:30 and 13:35 on settlement day
+        # (issue #66).  Near-close suppression also uses the early close
+        # so we don't warn during the last 10 min of real trading.
+        mins_left = minutes_until_session_close(self.order_symbol)
+        if mins_left is None:
+            return None
+        if mins_left <= self.NEAR_CLOSE_SUPPRESS:
             return None
 
         if now is None:

--- a/src/market_data/holidays.py
+++ b/src/market_data/holidays.py
@@ -113,8 +113,26 @@ def is_front_month_contract(order_symbol: str, d: date | datetime | None = None)
 
     Back-month contracts (May, June, ...) keep trading until 13:45 even
     on settlement day; only the front-month is force-settled at 13:30.
+
+    Also recognizes the static "near-month" placeholder codes used by
+    Capital API continuous-quote symbols (TX00 → "TXFD0", MTX00 →
+    "MTXFD0", TMF00 → "TM0000").  These don't match the standard
+    {letter}{digit} suffix but the broker auto-routes them to the
+    current front-month contract, so for settlement-day purposes they
+    behave as front-month.
     """
-    if not order_symbol or len(order_symbol) < 2:
+    if not order_symbol:
+        return False
+    # Near-month quote-symbol placeholders (issue #66): without this
+    # branch, is_front_month_contract("TM0000") returns False on
+    # settlement day and minutes_until_session_close keeps using 13:45
+    # instead of the actual 13:30 settlement close → false-positive
+    # watchdog warnings between 13:30 and 13:45.
+    from .kline_config import SYMBOL_CONFIG
+    for cfg in SYMBOL_CONFIG.values():
+        if cfg.get("near_month") and cfg.get("order_symbol") == order_symbol:
+            return True
+    if len(order_symbol) < 2:
         return False
     if d is None:
         from src.live.live_runner import _taipei_now

--- a/src/market_data/kline_config.py
+++ b/src/market_data/kline_config.py
@@ -51,13 +51,16 @@ LIVE_CHART_TIMEFRAMES = {
 
 SYMBOL_CONFIG = {
     "TX00": {"prefix": "TXF1", "tv": "TXF1!", "pv": 200, "tick_divisor": 100,
-             "taifex_id": "TX", "order_symbol": "TXFD0", "init_margin": 322000},
+             "taifex_id": "TX", "order_symbol": "TXFD0", "init_margin": 322000,
+             "near_month": True},
     "MTX00": {"prefix": "TMF1", "tv": "TMF1!", "pv": 50, "tick_divisor": 100,
               "taifex_id": "MTX", "order_symbol": "MTXFD0",
-              "kline_symbol": "TX00", "tick_symbol": "TX00", "init_margin": 80500},
+              "kline_symbol": "TX00", "tick_symbol": "TX00", "init_margin": 80500,
+              "near_month": True},
     "TMF00": {"prefix": "IMF1", "tv": "IMF1!", "pv": 10, "tick_divisor": 100,
               "taifex_id": "TMF", "order_symbol": "TM0000",
-              "kline_symbol": "TX00", "tick_symbol": "TX00", "init_margin": 16100},
+              "kline_symbol": "TX00", "tick_symbol": "TX00", "init_margin": 16100,
+              "near_month": True},
 }
 
 _MONTH_CODES = "ABCDEFGHIJKL"  # A=Jan .. L=Dec

--- a/tests/test_settlement_day.py
+++ b/tests/test_settlement_day.py
@@ -114,6 +114,19 @@ class TestIsFrontMonthContract:
         assert is_front_month_contract("", d) is False
         assert is_front_month_contract("X", d) is False
 
+    def test_near_month_placeholder_symbols_are_front_month(self):
+        """Issue #66: continuous-quote symbols TX00/MTX00/TMF00 use
+        static placeholder order_symbol values that don't match the
+        {letter}{digit} suffix pattern. Without recognizing them,
+        settlement-day detection fails for these (very common) symbols."""
+        d = date(2026, 5, 20)  # settlement day for May
+        # Capital API auto-routes these to current front-month
+        assert is_front_month_contract("TM0000", d) is True   # TMF00
+        assert is_front_month_contract("TXFD0", d) is True    # TX00
+        assert is_front_month_contract("MTXFD0", d) is True   # MTX00
+        # Real back-month code on the same date — not front-month
+        assert is_front_month_contract("TXFF6", d) is False   # June 2026
+
     def test_accepts_datetime(self):
         dt = datetime(2026, 4, 15, 9, 0, tzinfo=_TPE)
         assert is_front_month_contract("TXFD6", dt) is True

--- a/tests/test_tick_watchdog.py
+++ b/tests/test_tick_watchdog.py
@@ -150,6 +150,70 @@ class TestWeekendTransition:
         assert action == "session_resubscribe"
 
 
+class TestSettlementDayClose:
+    """Issue #66 part 2: on settlement day (3rd Wed), front-month
+    contracts force-settle at 13:30. Without symbol-aware close
+    handling, the watchdog uses the default 13:45 and warns/escalates
+    between 13:30 and 13:45 when ticks correctly stop at 13:30.
+    """
+
+    def test_settlement_no_warning_between_1330_and_1345(self):
+        """Last tick at 13:28 (just before settlement close), check at
+        13:32 with order_symbol=TM0000 (TMF00 front-month) → no warn.
+
+        With the bug: default 13:45 close, mins_left=13 (not near close),
+        elapsed=4min > WARN_TIMEOUT → "warn".
+        """
+        wd = TickWatchdog()
+        wd.active = True
+        wd.order_symbol = "TM0000"  # front-month placeholder for TMF00
+
+        last_tick = _taipei_dt(2026, 5, 20, 13, 28)  # settlement day
+        wd.last_tick_time = _ts(last_tick)
+
+        check_dt = _taipei_dt(2026, 5, 20, 13, 32)
+        with _patch_now(check_dt):
+            action = wd.check(now=_ts(check_dt))
+        assert action is None  # past effective close, no warning
+
+    def test_settlement_no_warning_at_1334(self):
+        wd = TickWatchdog()
+        wd.active = True
+        wd.order_symbol = "TM0000"
+        last_tick = _taipei_dt(2026, 5, 20, 13, 28)
+        wd.last_tick_time = _ts(last_tick)
+        check_dt = _taipei_dt(2026, 5, 20, 13, 34)
+        with _patch_now(check_dt):
+            assert wd.check(now=_ts(check_dt)) is None
+
+    def test_non_settlement_day_still_warns_after_1330(self):
+        """On a non-settlement day, 13:30-13:45 is regular trading,
+        so a stale tick from 13:29 SHOULD trigger warn at 13:32."""
+        wd = TickWatchdog()
+        wd.active = True
+        wd.order_symbol = "TM0000"
+        # 2026-05-19 is Tuesday, NOT settlement day
+        last_tick = _taipei_dt(2026, 5, 19, 13, 29)  # 3 min before check
+        wd.last_tick_time = _ts(last_tick)
+        check_dt = _taipei_dt(2026, 5, 19, 13, 32)
+        with _patch_now(check_dt):
+            action = wd.check(now=_ts(check_dt))
+        assert action == "warn"
+
+    def test_settlement_back_month_uses_1345_close(self):
+        """Back-month contracts (e.g. June TXFF6) close at 13:45 even
+        on settlement day — the early close only applies to front-month."""
+        wd = TickWatchdog()
+        wd.active = True
+        wd.order_symbol = "TXFF6"  # June 2026, back-month on May settlement day
+        last_tick = _taipei_dt(2026, 5, 20, 13, 29)
+        wd.last_tick_time = _ts(last_tick)
+        check_dt = _taipei_dt(2026, 5, 20, 13, 32)
+        with _patch_now(check_dt):
+            action = wd.check(now=_ts(check_dt))
+        assert action == "warn"
+
+
 class TestNormalStaleness:
     """Normal tick staleness during an active session."""
 


### PR DESCRIPTION
## Summary
Addresses the settlement-day part of #66. On settlement day (3rd Wed of the month), the front-month contract force-settles at 13:30, ticks correctly stop, but the watchdog kept warning every 30s between 13:30 and 13:35 because settlement-day detection silently no-op'd for TMF00.

## Bug log (settlement day 2026-05-20, bot 0422)
```
[13:29:00] 1分K 1m: 13:28 O=40078 C=40078 V=141
[13:32:01] 警告 No ticks for 2m
[13:33:02] 警告 No ticks for 3m
[13:34:03] 警告 No ticks for 4m
```

## Why settlement detection didn't fire
- `SYMBOL_CONFIG["TMF00"]["order_symbol"] == "TM0000"` — a Capital API static placeholder for the auto-routed front-month contract.
- `is_front_month_contract("TM0000", ...)` parses the last two chars expecting `{month_letter}{year_digit}` (e.g. `"E6"` for May 2026). `"00"` doesn't match anything → **always returned False**.
- `_am_close_minutes` therefore returned `825` (13:45) instead of `810` (13:30).
- And `TickWatchdog.check()` never passed `order_symbol` to `minutes_until_session_close` anyway.

## Fix
1. `SYMBOL_CONFIG`: tag TX00/MTX00/TMF00 with `near_month: True` — these continuous quote symbols always track the front-month contract regardless of the static order_symbol value.
2. `is_front_month_contract`: reverse-lookup `near_month` placeholders in SYMBOL_CONFIG before the suffix-pattern check. `"TM0000"`, `"TXFD0"`, `"MTXFD0"` all return True on any settlement day. The standard pattern check for real contract codes (`TXFE6` etc.) is preserved.
3. `TickWatchdog`: new `order_symbol` attribute, passed to `minutes_until_session_close`. Treat `mins_left is None` during open market as "past effective close" — suppress all alerts so the 13:30-13:45 window is quiet on settlement day.
4. GUI sets `self._tick_watchdog.order_symbol = resolve_order_symbol(symbol)` right after the tick subscription succeeds.

## Scope note
This is a narrow fix focused on settlement-day detection. The session-resubscribe loop and false-positive 90m force-reconnect symptoms from #66 are addressed in a separate PR (#67) and were intentionally left out of this one.

## Test plan
- [x] `TestSettlementDayClose` (new) — settlement-day 13:30 quiet for TMF00, still warns on non-settlement days, back-month TXFF6 still uses 13:45
- [x] `TestIsFrontMonthContract::test_near_month_placeholder_symbols_are_front_month` — TM0000/TXFD0/MTXFD0 recognized
- [x] All 955 existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)