### PR TITLE
fix(tick_watchdog): break the resubscribe loop at session open (re: #66)

### DIFF
--- a/run_backtest.py
+++ b/run_backtest.py
@@ -4030,6 +4030,11 @@ class BacktestApp:
             self._live_log_msg(
                 "新盤重新訂閱 New session — re-subscribing ticks", "status")
             self._resubscribe_ticks()
+            # Advance last_tick_time so the trigger condition clears.
+            # Without this, every 30s check re-fires session_resubscribe
+            # forever because last_tick_time still corresponds to the
+            # prior closed-market period (issue #66).
+            self._tick_watchdog.on_session_resubscribe()
 
         elif action == "reconnect":
             _log(f"Tick watchdog: no ticks for {mins}m, forcing full reconnect")

--- a/src/live/tick_watchdog.py
+++ b/src/live/tick_watchdog.py
@@ -64,6 +64,27 @@ class TickWatchdog:
         """
         self.last_resubscribe = time.time()
 
+    def on_session_resubscribe(self) -> None:
+        """Call after issuing a session-transition resubscribe.
+
+        Unlike on_resubscribe(), this DOES advance last_tick_time to
+        wall-clock now.  Rationale: the session_resubscribe trigger fires
+        when last_tick_time was set during a wall-clock closed-market
+        period (e.g. a subscription-time auto-tick at 14:50, fired during
+        the 13:45-15:00 gap).  Without advancing last_tick_time, every
+        subsequent check() at 30s cadence keeps seeing the same
+        "last tick was during closed market" condition and re-fires
+        session_resubscribe forever (issue #66).
+
+        Advancing last_tick_time restarts the normal staleness clock.
+        If ticks really aren't arriving (zombie session), the regular
+        warn→resubscribe→reconnect escalation kicks in after WARN_TIMEOUT.
+        Real ticks will reset state via on_tick() as usual.
+        """
+        now = time.time()
+        self.last_tick_time = now
+        self.last_resubscribe = now
+
     def set_grace(self, seconds: int = 30) -> None:
         """Set a grace period after reconnect/resubscribe."""
         self.grace_until = time.time() + seconds

--- a/src/live/tick_watchdog.py
+++ b/src/live/tick_watchdog.py
@@ -12,6 +12,38 @@ from datetime import datetime
 from .live_runner import is_market_open, minutes_until_session_close, _TZ_TAIPEI
 
 
+def _crossed_session_gap(last_ts: float, now_ts: float) -> bool:
+    """Return True if a market-closed period exists between last_ts and now_ts.
+
+    Used to distinguish session boundary crossings from same-session
+    zombie scenarios.  Both:
+
+      * last tick during closed market (e.g. subscription auto-tick at 14:50
+        during the 13:45-15:00 gap), and
+      * last tick during prior session (e.g. last AM tick at 13:28, check at
+        15:00 PM open — bot 0422 case from issue #66)
+
+    are session-boundary scenarios that warrant a soft resubscribe rather
+    than a 10-minute-elapsed reconnect.
+    """
+    if now_ts <= last_ts:
+        return False
+    last_dt = datetime.fromtimestamp(last_ts, tz=_TZ_TAIPEI)
+    # If last tick was itself during closed market, definitely a gap
+    if not is_market_open(last_dt):
+        return True
+    # Walk the interval in 5-min steps looking for a closed sample.
+    # Real session gaps are >= 75 min (13:45-15:00) or >= 225 min (05:00-08:45),
+    # so 5-min stride catches them with tens of iterations max.
+    step = 300
+    t = last_ts + step
+    while t < now_ts:
+        if not is_market_open(datetime.fromtimestamp(t, tz=_TZ_TAIPEI)):
+            return True
+        t += step
+    return False
+
+
 class TickWatchdog:
     """Monitors tick freshness and decides when to resubscribe or reconnect.
 
@@ -68,13 +100,13 @@ class TickWatchdog:
         """Call after issuing a session-transition resubscribe.
 
         Unlike on_resubscribe(), this DOES advance last_tick_time to
-        wall-clock now.  Rationale: the session_resubscribe trigger fires
-        when last_tick_time was set during a wall-clock closed-market
-        period (e.g. a subscription-time auto-tick at 14:50, fired during
-        the 13:45-15:00 gap).  Without advancing last_tick_time, every
-        subsequent check() at 30s cadence keeps seeing the same
-        "last tick was during closed market" condition and re-fires
-        session_resubscribe forever (issue #66).
+        wall-clock now.  Rationale: the session_resubscribe trigger
+        fires when a closed-market gap exists between last_tick_time
+        and now — e.g. a subscription-time auto-tick at 14:50 during
+        the 13:45-15:00 gap, OR a normal last AM tick at 13:28 with
+        check at 15:00 PM open.  In either case the elapsed reading
+        across the gap is meaningless and the trigger condition would
+        keep firing on every 30s check.
 
         Advancing last_tick_time restarts the normal staleness clock.
         If ticks really aren't arriving (zombie session), the regular
@@ -137,13 +169,27 @@ class TickWatchdog:
         if now < self.grace_until:
             return None
 
-        # Session transition: last tick was during closed market.
-        # The old subscription is stale — resubscribe immediately.
-        last_dt = datetime.fromtimestamp(self.last_tick_time, tz=_TZ_TAIPEI)
-        if not is_market_open(last_dt):
-            return "session_resubscribe"
+        # Session boundary: a closed-market period exists between last
+        # tick and now (last tick during closed gap, or last tick in a
+        # prior session).  Prefer a soft resubscribe over a heavy
+        # reconnect — the 90+ minute elapsed reading is a measurement
+        # artifact of the gap, not a real zombie session.
+        #
+        # RESUBSCRIBE_COOLDOWN prevents the 30s-check loop; the GUI
+        # handler should also call on_session_resubscribe() to advance
+        # last_tick_time so subsequent checks see a fresh clock.  If
+        # ticks still don't arrive, normal warn → resubscribe →
+        # reconnect escalation takes over within minutes.
+        if _crossed_session_gap(self.last_tick_time, now):
+            in_cooldown = (self.last_resubscribe
+                           and (now - self.last_resubscribe) < self.RESUBSCRIBE_COOLDOWN)
+            if not in_cooldown:
+                return "session_resubscribe"
+            # In cooldown: stay quiet rather than escalating to reconnect
+            # on a stale elapsed reading that spans the closed gap.
+            return None
 
-        # Normal staleness checks
+        # Normal staleness checks (same-session zombie)
         elapsed = now - self.last_tick_time
         if elapsed <= self.WARN_TIMEOUT:
             return None

--- a/tests/test_tick_watchdog.py
+++ b/tests/test_tick_watchdog.py
@@ -54,8 +54,15 @@ class TestSessionTransitionAMtoPM:
             action = wd.check(now=_ts(check_dt))
         assert action == "session_resubscribe"
 
-    def test_last_tick_at_am_close_triggers_reconnect(self):
-        """Tick at 13:44 (AM open), check at 15:01 → reconnect (>10min elapsed)."""
+    def test_last_tick_at_am_close_triggers_session_resubscribe(self):
+        """Tick at 13:44 (AM open), check at 15:01 → session_resubscribe.
+
+        Issue #66 (bot 0422 case): even when last tick was in the prior
+        session (not in the gap itself), the elapsed measurement spans the
+        13:45-15:00 closed gap, so the 77-min reading is a measurement
+        artifact. Prefer a soft resubscribe over a heavy reconnect; if
+        ticks really don't arrive, normal escalation kicks in afterward.
+        """
         wd = TickWatchdog()
         wd.active = True
 
@@ -63,18 +70,23 @@ class TestSessionTransitionAMtoPM:
         am_dt = _taipei_dt(2026, 3, 17, 13, 44)
         wd.last_tick_time = _ts(am_dt)
 
-        # Check at 15:01 — elapsed ~77min, last tick was during open market
+        # Check at 15:01 — elapsed ~77min, but spans the closed gap
         check_dt = _taipei_dt(2026, 3, 17, 15, 1)
         with _patch_now(check_dt):
             action = wd.check(now=_ts(check_dt))
-        assert action == "reconnect"  # >10min elapsed
+        assert action == "session_resubscribe"
 
 
 class TestSessionTransitionPMtoAM:
     """PM session closes 05:00, AM opens 08:45 next day."""
 
-    def test_last_tick_before_close_triggers_reconnect(self):
-        """Tick at 04:59 (PM open), check at 08:46 → reconnect (>3h elapsed)."""
+    def test_last_tick_before_close_triggers_session_resubscribe(self):
+        """Tick at 04:59 (PM open), check at 08:46 → session_resubscribe.
+
+        Last tick was just before the 05:00 night close; check at next
+        AM open. Elapsed (~3h47m) spans the 05:00-08:45 closed gap, so
+        it's a session boundary not a same-session zombie.
+        """
         wd = TickWatchdog()
         wd.active = True
 
@@ -82,11 +94,11 @@ class TestSessionTransitionPMtoAM:
         pm_dt = _taipei_dt(2026, 3, 18, 4, 59)
         wd.last_tick_time = _ts(pm_dt)
 
-        # Check at 08:46 — elapsed ~3h47m, last tick during open market
+        # Check at 08:46 — gap spans 05:00-08:45 closed period
         check_dt = _taipei_dt(2026, 3, 18, 8, 46)
         with _patch_now(check_dt):
             action = wd.check(now=_ts(check_dt))
-        assert action == "reconnect"
+        assert action == "session_resubscribe"
 
     def test_last_tick_at_close_triggers_session_resubscribe(self):
         """Tick at 05:01 (market closed), check at 08:46 → session_resubscribe."""
@@ -107,33 +119,36 @@ class TestWeekendTransition:
     """Friday PM → Saturday 05:00 close → Monday AM 08:45 open."""
 
     def test_friday_night_tick_monday_morning(self):
-        """Last tick Friday 23:00, check Monday 08:46 → reconnect."""
+        """Last tick Friday 23:00, check Monday 08:46 → session_resubscribe.
+
+        Multi-day gap is still a session boundary — start with the soft
+        action; if the COM session is actually dead, the resubscribe will
+        fail (returning an error from RequestTicks) or no ticks will
+        arrive, and the normal escalation reaches reconnect within minutes.
+        """
         wd = TickWatchdog()
         wd.active = True
 
-        # Friday night tick (market open)
         fri_dt = _taipei_dt(2026, 3, 20, 23, 0)  # Friday
         wd.last_tick_time = _ts(fri_dt)
 
-        # Monday morning (AM open)
         mon_dt = _taipei_dt(2026, 3, 23, 8, 46)  # Monday
         with _patch_now(mon_dt):
             action = wd.check(now=_ts(mon_dt))
-        assert action == "reconnect"  # >2 days elapsed, last tick was open market
+        assert action == "session_resubscribe"
 
     def test_saturday_morning_tick_monday(self):
         """Last tick Saturday 04:59 (Fri night carryover), check Monday 08:46."""
         wd = TickWatchdog()
         wd.active = True
 
-        # Saturday 04:59 (market still open from Friday night)
         sat_dt = _taipei_dt(2026, 3, 21, 4, 59)  # Saturday
         wd.last_tick_time = _ts(sat_dt)
 
         mon_dt = _taipei_dt(2026, 3, 23, 8, 46)
         with _patch_now(mon_dt):
             action = wd.check(now=_ts(mon_dt))
-        assert action == "reconnect"
+        assert action == "session_resubscribe"
 
     def test_saturday_after_close_monday(self):
         """Last tick Saturday 06:00 (closed), check Monday 08:46 → session_resubscribe."""
@@ -212,6 +227,66 @@ class TestSettlementDayClose:
         with _patch_now(check_dt):
             action = wd.check(now=_ts(check_dt))
         assert action == "warn"
+
+
+class TestBot0422FalseReconnect:
+    """Issue #66: bot 0422 case.
+
+    Last real tick at 13:28 (AM session), no more ticks (settlement day or
+    cash-market early close), watchdog warns 13:32-13:34, suppressed
+    13:35-13:45, market closes 13:45, reopens 15:00 → watchdog measures
+    90 min elapsed and force-reconnects.
+
+    The 90-min reading is a measurement artifact across the closed gap,
+    not a zombie session. The fix should treat this as a session boundary
+    (soft resubscribe), not escalate straight to reconnect.
+    """
+
+    def test_first_pm_check_resubscribes_not_reconnects(self):
+        """At 15:00:22 first check after PM open, action must be
+        session_resubscribe (not the buggy 90m force-reconnect)."""
+        wd = TickWatchdog()
+        wd.active = True
+
+        last_tick = _taipei_dt(2026, 5, 20, 13, 28)
+        wd.last_tick_time = _ts(last_tick)
+
+        check_dt = _taipei_dt(2026, 5, 20, 15, 0)
+        with _patch_now(check_dt):
+            action = wd.check(now=_ts(check_dt) + 22)  # 15:00:22
+        assert action == "session_resubscribe"
+
+    def test_no_reconnect_loop_after_handler(self):
+        """After handler runs on_session_resubscribe, subsequent checks
+        must NOT keep firing — neither session_resubscribe nor reconnect."""
+        wd = TickWatchdog()
+        wd.active = True
+
+        last_tick = _taipei_dt(2026, 5, 20, 13, 28)
+        wd.last_tick_time = _ts(last_tick)
+
+        check_dt = _taipei_dt(2026, 5, 20, 15, 0)
+        first = _ts(check_dt) + 22
+        with _patch_now(check_dt):
+            assert wd.check(now=first) == "session_resubscribe"
+
+        # Handler runs at 15:00:22
+        with patch("src.live.tick_watchdog.time.time", return_value=first):
+            wd.set_grace(30)
+            wd.on_session_resubscribe()
+
+        # 30s later, grace expired — must be quiet, NOT reconnect
+        second = first + 30
+        second_dt = datetime.fromtimestamp(second, tz=_TZ_TAIPEI)
+        with _patch_now(second_dt):
+            action2 = wd.check(now=second)
+        assert action2 is None
+
+        # Another minute — still quiet
+        third = first + 90
+        third_dt = datetime.fromtimestamp(third, tz=_TZ_TAIPEI)
+        with _patch_now(third_dt):
+            assert wd.check(now=third) is None
 
 
 class TestNormalStaleness:

--- a/tests/test_tick_watchdog.py
+++ b/tests/test_tick_watchdog.py
@@ -416,6 +416,129 @@ class TestResubscribeCooldown:
             action = wd.check(now=_ts(fake_now_dt))
         assert action == "reconnect"
 
+    def test_on_session_resubscribe_advances_last_tick_time(self):
+        """on_session_resubscribe must reset last_tick_time so the
+        session_resubscribe trigger condition clears (issue #66)."""
+        wd = TickWatchdog()
+        # last tick from a closed-market wall-clock time
+        gap_dt = _taipei_dt(2026, 5, 19, 14, 50)  # AM/PM gap
+        wd.last_tick_time = _ts(gap_dt)
+        before_resub = wd.last_tick_time
+
+        wd.on_session_resubscribe()
+
+        assert wd.last_tick_time > before_resub
+        assert wd.last_resubscribe > 0
+        # last_tick_time should be approximately wall-clock now
+        assert abs(wd.last_tick_time - time.time()) < 1.0
+
+    def test_session_resubscribe_does_not_loop_after_handler_call(self):
+        """Issue #66 regression: subscribe during 13:45-15:00 gap, then
+        session_resubscribe fires once at 15:00. After the handler runs
+        on_session_resubscribe(), subsequent checks must NOT keep firing
+        session_resubscribe at every 30s watchdog tick."""
+        wd = TickWatchdog()
+        wd.active = True
+
+        # Subscription at 14:47:50 sets last_tick_time during the gap
+        sub_dt = _taipei_dt(2026, 5, 19, 14, 47)
+        wd.last_tick_time = _ts(sub_dt)
+
+        # First check at 15:00:24 — fires session_resubscribe
+        check1 = _taipei_dt(2026, 5, 19, 15, 0)
+        with _patch_now(check1):
+            action1 = wd.check(now=_ts(check1) + 24)
+        assert action1 == "session_resubscribe"
+
+        # Handler runs: _resubscribe_ticks (sets grace=30) then
+        # on_session_resubscribe (advances last_tick_time to now)
+        with patch("src.live.tick_watchdog.time.time",
+                   return_value=_ts(check1) + 24):
+            wd.set_grace(30)
+            wd.on_session_resubscribe()
+
+        # Next check 30s later — grace expired, but last_tick_time is now
+        # fresh, so no session_resubscribe loop
+        check2 = _ts(check1) + 54
+        check2_dt = datetime.fromtimestamp(check2, tz=_TZ_TAIPEI)
+        with _patch_now(check2_dt):
+            action2 = wd.check(now=check2)
+        assert action2 is None  # Loop is broken
+
+        # Check several more cycles to confirm no loop
+        for offset in (84, 114, 144):
+            t = _ts(check1) + offset
+            t_dt = datetime.fromtimestamp(t, tz=_TZ_TAIPEI)
+            with _patch_now(t_dt):
+                assert wd.check(now=t) is None
+
+    def test_session_resubscribe_zombie_escalates_to_warn_then_reconnect(self):
+        """If after a session_resubscribe ticks STILL don't arrive (true
+        zombie session), the watchdog must escalate via normal staleness
+        ladder rather than silently swallowing the problem."""
+        wd = TickWatchdog()
+        wd.active = True
+
+        # Subscription during gap → session_resubscribe at PM open
+        sub_dt = _taipei_dt(2026, 5, 19, 14, 47)
+        wd.last_tick_time = _ts(sub_dt)
+        check1 = _taipei_dt(2026, 5, 19, 15, 0)
+        with _patch_now(check1):
+            assert wd.check(now=_ts(check1) + 24) == "session_resubscribe"
+
+        # Handler does on_session_resubscribe at 15:00:24
+        handler_t = _ts(check1) + 24
+        with patch("src.live.tick_watchdog.time.time",
+                   return_value=handler_t):
+            wd.on_session_resubscribe()
+            # No grace this time — testing escalation purely on elapsed
+            wd.grace_until = 0
+
+        # 3 min later — should warn (no ticks ever arrived)
+        t_warn = handler_t + 150  # > WARN_TIMEOUT (120)
+        t_warn_dt = datetime.fromtimestamp(t_warn, tz=_TZ_TAIPEI)
+        with _patch_now(t_warn_dt):
+            assert wd.check(now=t_warn) == "warn"
+
+        # 11 min later — should reconnect
+        t_reconnect = handler_t + 700  # > RECONNECT_TIMEOUT (600)
+        t_reconnect_dt = datetime.fromtimestamp(t_reconnect, tz=_TZ_TAIPEI)
+        with _patch_now(t_reconnect_dt):
+            assert wd.check(now=t_reconnect) == "reconnect"
+
+    def test_session_resubscribe_recovers_when_real_ticks_arrive(self):
+        """After session_resubscribe, if real ticks do arrive, the
+        watchdog should remain quiet — on_tick() resets everything."""
+        wd = TickWatchdog()
+        wd.active = True
+
+        sub_dt = _taipei_dt(2026, 5, 19, 14, 47)
+        wd.last_tick_time = _ts(sub_dt)
+        check1 = _taipei_dt(2026, 5, 19, 15, 0)
+        with _patch_now(check1):
+            assert wd.check(now=_ts(check1) + 24) == "session_resubscribe"
+
+        handler_t = _ts(check1) + 24
+        with patch("src.live.tick_watchdog.time.time",
+                   return_value=handler_t):
+            wd.on_session_resubscribe()
+
+        # A real tick at 15:00:30
+        tick_t = handler_t + 6
+        with patch("src.live.tick_watchdog.time.time",
+                   return_value=tick_t):
+            wd.on_tick()
+        assert wd.last_resubscribe == 0.0  # cleared by on_tick
+
+        # Subsequent checks are quiet
+        for offset in (30, 60, 90, 120):
+            t = tick_t + offset
+            t_dt = datetime.fromtimestamp(t, tz=_TZ_TAIPEI)
+            with _patch_now(t_dt):
+                # last_tick_time = tick_t, elapsed = offset
+                # All under WARN_TIMEOUT
+                assert wd.check(now=t) is None
+
     def test_zombie_session_eventually_escalates_to_reconnect(self):
         """End-to-end zombie scenario: tick stops at T=0, resubscribes at
         T=300 (fails silently), by T=700 we should reconnect."""


### PR DESCRIPTION
## Recovery PR — restores the loop-fix that was dropped from PR #68

PR #68 merged only one of the three commits from PR #67 — the settlement-day 13:30 close fix. The other two commits (the actual loop fix + broader session-boundary detection) were never merged, so the original `新盤重新訂閱` loop is still hitting production.

**Evidence the bug is live right now:** bot 0422's debug log shows the loop firing every ~30s for 4+ hours straight, starting at 2026-06-03 08:45:16 (AM session open):

```
[2026-06-03 08:45:16] 新盤重新訂閱 New session — re-subscribing ticks
[2026-06-03 08:45:46] 新盤重新訂閱 New session — re-subscribing ticks
[2026-06-03 08:46:16] 新盤重新訂閱 ... (continues for 4 hours, 478+ iterations)
[2026-06-03 12:34:13] 新盤重新訂閱 New session — re-subscribing ticks
```

`tick_watchdog.py` on master currently has zero references to `on_session_resubscribe` or `_crossed_session_gap` — confirming the fix never landed.

## What this PR contains
Cherry-picks the two missing commits from the original PR #67:

1. **`9f99352` — break the loop** — adds `TickWatchdog.on_session_resubscribe()` that advances `last_tick_time` to wall-clock now after a session-transition resubscribe. Without this, the trigger condition stays True forever and the watchdog re-fires every 30s.
2. **`cfd2e94` — broader detection** — adds `_crossed_session_gap(last_ts, now_ts)` that detects any closed-market period between last tick and now. Catches the bot 0422 false 90m-reconnect case where the last tick was in the *prior* session, not in the gap itself.

Both commits are identical to what PR #67 had — no new code, just recovering what was dropped.

## Test plan
- [x] `TestBot0422FalseReconnect` covers the exact reproducer from the original issue
- [x] `test_session_resubscribe_does_not_loop_after_handler_call` covers the loop fix
- [x] `test_session_resubscribe_zombie_escalates_to_warn_then_reconnect` confirms escalation still works
- [x] `TestSettlementDayClose` (from PR #68) still passes — settlement-day quietness is preserved
- [x] All 1066 tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)