### PR TITLE
fix(reconnect): three 0422 reconnect bugs + structured logging

### DIFF
--- a/run_backtest.py
+++ b/run_backtest.py
@@ -4381,17 +4381,32 @@ class BacktestApp:
         )
         # Mirror the verdict in the live log so the user can see WHY a
         # notification did or didn't fire — debugging "why no Discord"
-        # is otherwise a paper trail of nothing.
+        # is otherwise a paper trail of nothing.  Improvement lines
+        # carry the same detail as the Discord message so the debug
+        # log file is a complete audit trail without scrolling Discord.
+        fit = verdict.fitness
         if verdict.send_notification:
-            self._live_log_msg(
-                f"📈 策略進步 Strategy improvement: composite "
-                f"{verdict.fitness.composite:.3f} (Δ {verdict.delta:+.3f})",
-                "status",
+            detail = (
+                f"📈 策略進步 Strategy improvement: "
+                f"composite {fit.composite:.3f} "
+                f"(前最佳 prev best {verdict.previous_best:.3f}, "
+                f"Δ {verdict.delta:+.3f}) | "
+                f"交易數 trades {fit.total_trades} | "
+                f"勝率 win-rate {fit.win_rate*100:.1f}% | "
+                f"PF {fit.profit_factor:.2f} | "
+                f"Sortino {fit.sortino:.2f} | "
+                f"最大回撤 max DD {fit.max_drawdown_pct*100:.1f}% | "
+                f"來源 source {fit.source}"
             )
+            self._live_log_msg(detail, "status")
+            # Also a copy in the un-prefixed debug log so a `grep
+            # "Strategy improvement"` over debug_YYYYMMDD.log finds it
+            # without the [LIVE] marker getting in the way.
+            _log(detail)
         else:
             self._live_log_msg(
                 f"演化評分 Fitness: composite "
-                f"{verdict.fitness.composite:.3f} — {verdict.reason}",
+                f"{fit.composite:.3f} — {verdict.reason}",
                 "status",
             )
 

--- a/run_backtest.py
+++ b/run_backtest.py
@@ -4299,7 +4299,15 @@ class BacktestApp:
             self._handle_semi_auto_order(decision)
 
     def _on_live_daily_report(self, report: dict) -> None:
-        """Forward end-of-session daily report to Discord and the live log."""
+        """Forward end-of-session daily report to Discord and the live log.
+
+        After the standard daily-report Discord post, also runs the
+        evolution-notify hook: score the bot's accumulated trades, compare
+        against the persisted baseline, and announce on improvement
+        (issue: strategy-improvement notifications missing). All
+        evolution work is best-effort — daily report must never fail
+        because of fitness scoring or Discord side-effects.
+        """
         date = report.get("date", "?")
         summary = report.get("summary", {}) or {}
         self._live_log_msg(
@@ -4313,6 +4321,79 @@ class BacktestApp:
                 _discord.daily_report(report)
             except Exception:
                 pass  # best-effort; never block on notification failure
+
+        # Evolution: fitness scoring + improvement notification.
+        try:
+            self._run_evolution_check_after_report()
+        except Exception as e:
+            _log(f"evolution notify hook failed: [{type(e).__name__}] {e}")
+
+    def _run_evolution_check_after_report(self) -> None:
+        """Score the running bot and fire a Discord notification on improvement.
+
+        Extracted from ``_on_live_daily_report`` so the broad
+        ``try/except`` wrapping it can't accidentally swallow logic
+        bugs in the daily-report path itself.  Kept private because
+        the only correct call site is the daily-report callback.
+        """
+        if self._live_runner is None:
+            return
+        broker = getattr(self._live_runner, "broker", None)
+        if broker is None:
+            return
+        trades = list(getattr(broker, "trades", []) or [])
+        if not trades:
+            return  # nothing to score yet
+        equity_curve = list(getattr(broker, "equity_curve", []) or [])
+        bot_dir = getattr(self._live_runner, "bot_dir", None)
+        if not bot_dir:
+            return
+
+        from src.evolution.notify import (
+            check_and_notify_after_report,
+            ImprovementVerdict,
+        )
+
+        def _send(verdict: ImprovementVerdict) -> None:
+            if _discord is None or not _discord.enabled:
+                return
+            fit = verdict.fitness
+            _discord.strategy_improved(
+                composite=fit.composite,
+                previous_best=verdict.previous_best,
+                delta=verdict.delta,
+                n_trades=fit.total_trades,
+                sortino=fit.sortino,
+                win_rate=fit.win_rate,
+                profit_factor=fit.profit_factor,
+                max_drawdown_pct=fit.max_drawdown_pct,
+                source=fit.source,
+                first_run=(verdict.previous_best == 0.0
+                          and "first scored" in verdict.reason),
+            )
+
+        verdict = check_and_notify_after_report(
+            bot_dir=bot_dir,
+            trades=trades,
+            equity_curve=equity_curve,
+            trading_mode=getattr(self, "_trading_mode", None),
+            send_notification=_send,
+        )
+        # Mirror the verdict in the live log so the user can see WHY a
+        # notification did or didn't fire — debugging "why no Discord"
+        # is otherwise a paper trail of nothing.
+        if verdict.send_notification:
+            self._live_log_msg(
+                f"📈 策略進步 Strategy improvement: composite "
+                f"{verdict.fitness.composite:.3f} (Δ {verdict.delta:+.3f})",
+                "status",
+            )
+        else:
+            self._live_log_msg(
+                f"演化評分 Fitness: composite "
+                f"{verdict.fitness.composite:.3f} — {verdict.reason}",
+                "status",
+            )
 
     # ── Semi-auto real order handling ──
 

--- a/run_backtest.py
+++ b/run_backtest.py
@@ -385,6 +385,35 @@ def _log(msg):
             pass
 
 
+def _log_debug(msg):
+    """DEBUG-level log for reconnect / watchdog / tick-subscription diagnostics.
+
+    Always captured to the per-session debug log file with both Taipei and
+    local wall-clock timestamps. Printed to console with a ``[DEBUG]`` prefix
+    so it can be filtered with ``grep -v '[DEBUG]'``. NOT pushed to the
+    Tkinter live-event widget so it doesn't drown out user-facing messages.
+
+    Use one of the structured tag prefixes inside ``msg`` to make later
+    triage easier: ``[CONN]``, ``[RECONNECT]``, ``[TICKS]``, ``[WATCHDOG]``,
+    ``[STATE]``.
+    """
+    tpe = _taipei_now()
+    local = datetime.now()
+    ts_tpe = tpe.strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+    ts_local = local.strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+    if ts_tpe[:19] == ts_local[:19]:
+        line = f"[{ts_tpe}] [DEBUG] {msg}"
+    else:
+        line = f"[{ts_tpe} TPE / {ts_local} local] [DEBUG] {msg}"
+    print(line, flush=True)
+    if _debug_log_file:
+        try:
+            _debug_log_file.write(line + "\n")
+            _debug_log_file.flush()
+        except Exception:
+            pass
+
+
 # ── COM Event handlers ──
 
 class SKQuoteLibEvents:
@@ -394,10 +423,21 @@ class SKQuoteLibEvents:
     def OnConnection(self, nKind, nCode):
         kind_names = {3001: "Reply", 3002: "Quote", 3003: "Ready",
                       3021: "ConnError", 3033: "Abnormal"}
+        kind_label = kind_names.get(nKind, str(nKind))
         # Only queue.put_nowait() is safe from COM background threads.
         # root.after() is NOT safe — it calls into Tcl/Tk C code which
         # is not thread-safe and corrupts the GIL in Python 3.13.
-        _ui_queue.put_nowait(("log", f"報價連線 QUOTE CONN: {kind_names.get(nKind, nKind)} code={nCode}"))
+        _ui_queue.put_nowait(("log", f"報價連線 QUOTE CONN: {kind_label} code={nCode}"))
+        # Structured DEBUG line per OnConnection event — meaning of each kind
+        # is documented inline so a future debugger can read it cold.
+        meaning = {
+            3001: "Reply — order/reply channel up (intermediate, NOT fully connected)",
+            3002: "Quote — quote channel up (intermediate, waiting for Ready 3003)",
+            3003: "Ready — fully connected, marking quote_connected=True",
+            3021: "ConnError — connection error, triggering disconnect",
+            3033: "Abnormal — abnormal disconnect, triggering disconnect",
+        }.get(nKind, f"unknown kind={nKind}")
+        _ui_queue.put_nowait(("log_debug", f"[CONN] kind={nKind} {kind_label} code={nCode} — {meaning}"))
         if nKind == 3003 and nCode == 0:
             _ui_queue.put_nowait(("conn", "ready"))
         elif nKind == 3002 and nCode == 0:
@@ -541,9 +581,15 @@ class BacktestApp:
                 kind, data = _ui_queue.get_nowait()
                 if kind == "log":
                     _log(data)
+                elif kind == "log_debug":
+                    _log_debug(data)
                 elif kind == "conn":
                     if data == "ready":
-                        self._quote_connected = True
+                        # Ready (3003) is the only state we treat as fully
+                        # connected. Cancel any pending "Quote → Ready"
+                        # watchdog since Ready arrived.
+                        self._cancel_quote_ready_timer("ready_received")
+                        self._set_quote_connected(True, "OnConnection(Ready)")
                         self.btn_api.config(state=tk.NORMAL)
                         self.btn_deploy.config(state=tk.NORMAL)
                         self.btn_login.config(state=tk.DISABLED)
@@ -551,15 +597,13 @@ class BacktestApp:
                         self.status_var.set("已連線 Connected - Ready")
                         self.login_status_var.set("已連線 Connected")
                         self._on_reconnected()
-                    elif data == "quote" and not self._quote_connected:
-                        self._quote_connected = True
-                        self.btn_api.config(state=tk.NORMAL)
-                        self.btn_deploy.config(state=tk.NORMAL)
-                        self.btn_login.config(state=tk.DISABLED)
-                        self.btn_reconnect.config(state=tk.NORMAL)
-                        self.status_var.set("已連線 Connected (Quote) - Ready")
-                        self.login_status_var.set("已連線 Connected")
-                        self._on_reconnected()
+                    elif data == "quote":
+                        # Bug A: Quote (3002) is intermediate, NOT fully
+                        # connected. RequestTicks may return OK on a session
+                        # that only reached Quote, but no ticks ever arrive
+                        # (zombie subscription). Wait for Ready (3003); if
+                        # it never comes, trigger a fresh reconnect attempt.
+                        self._on_quote_intermediate()
                     elif data == "disconnected":
                         self._on_disconnected()
                 elif kind == "account":
@@ -630,11 +674,78 @@ class BacktestApp:
     #  CONNECTION MONITORING & RECONNECTION
     # ══════════════════════════════════════════════════════════════
 
+    def _set_quote_connected(self, value: bool, caller: str) -> None:
+        """Assign self._quote_connected with a [STATE] debug log line.
+
+        Centralising the mutation makes every transition visible in the
+        debug log so a future reconnect-failure post-mortem can see who
+        flipped the flag and when.
+        """
+        old = self._quote_connected
+        if old != value:
+            _log_debug(
+                f"[STATE] _quote_connected: {old!r} -> {value!r} (caller={caller})")
+        self._quote_connected = value
+
+    def _on_quote_intermediate(self) -> None:
+        """Handle Quote (3002) — the intermediate state, not full ready.
+
+        Bug A: Quote alone is NOT enough to call ``_on_reconnected`` —
+        per CLAUDE.md the proper sequence is Reply(3001) → Quote(3002) →
+        Ready(3003). If we resubscribe ticks after only Quote, RequestTicks
+        returns OK but ticks never arrive (zombie subscription). Start a
+        15s timer; if Ready (3003) doesn't follow, treat it as a failed
+        attempt and trigger another reconnect cycle.
+        """
+        self._quote_intermediate_seen_at = time.time()
+        _log_debug(
+            "[CONN] Quote (3002) acknowledged — waiting up to 15s for "
+            "Ready (3003) before resubscribing ticks")
+        self._cancel_quote_ready_timer("quote_intermediate_arm")
+        self._quote_ready_timer_id = self.root.after(
+            15000, self._on_quote_ready_timeout)
+
+    def _on_quote_ready_timeout(self) -> None:
+        """Fired 15s after Quote (3002) if Ready (3003) never arrived.
+
+        Bug A escalation path: warn loudly so the session log shows what
+        happened, then trigger a fresh reconnect attempt rather than
+        sitting on a half-connected session that silently produces no
+        ticks.
+        """
+        self._quote_ready_timer_id = None
+        if self._quote_connected:
+            return  # Ready arrived between fire and now — nothing to do
+        waited = time.time() - (self._quote_intermediate_seen_at or time.time())
+        _log(
+            "報價未就緒 Quote (3002) seen but Ready (3003) did not arrive "
+            f"after {waited:.0f}s — triggering reconnect")
+        _log_debug(
+            f"[CONN] Ready (3003) timeout after {waited:.1f}s — forcing reconnect")
+        # Treat as a connection failure: kick the reconnect ladder so the
+        # GUI re-runs login+EnterMonitor cleanly instead of waiting forever.
+        self._on_disconnected()
+
+    def _cancel_quote_ready_timer(self, reason: str) -> None:
+        """Cancel the Quote→Ready watchdog timer if armed."""
+        if self._quote_ready_timer_id:
+            try:
+                self.root.after_cancel(self._quote_ready_timer_id)
+            except Exception:
+                pass
+            _log_debug(f"[CONN] Quote→Ready timer cancelled (reason={reason})")
+            self._quote_ready_timer_id = None
+            self._quote_intermediate_seen_at = 0.0
+
     def _on_disconnected(self):
         """Handle connection loss: pause live feed, start auto-reconnect."""
         if not self._quote_connected:
+            _log_debug(
+                "[STATE] _on_disconnected called but _quote_connected already False — "
+                "skipping (already handling disconnect)")
             return  # already handling disconnect
-        self._quote_connected = False
+        self._cancel_quote_ready_timer("disconnected")
+        self._set_quote_connected(False, "_on_disconnected")
         self.status_var.set("斷線 Disconnected")
         self.login_status_var.set("斷線 Disconnected")
         self.btn_login.config(state=tk.NORMAL)
@@ -648,6 +759,9 @@ class BacktestApp:
 
         # Start auto-reconnect
         self._conn_monitor.on_disconnected()
+        _log_debug(
+            f"[STATE] ConnectionMonitor: is_active=True, attempt=0 "
+            f"(caller=_on_disconnected)")
         self._schedule_reconnect()
 
     def _manual_reconnect(self):
@@ -656,13 +770,17 @@ class BacktestApp:
         if self._reconnect_timer_id:
             self.root.after_cancel(self._reconnect_timer_id)
             self._reconnect_timer_id = None
+        self._cancel_quote_ready_timer("manual_reconnect")
 
-        self._quote_connected = False
+        self._set_quote_connected(False, "_manual_reconnect")
         self.btn_reconnect.config(state=tk.DISABLED)
         action = self._conn_monitor.on_manual_reconnect()
         self.status_var.set(action.message)
         self.login_status_var.set("重連中 Reconnecting...")
         _log("手動重連 Manual reconnect triggered")
+        _log_debug(
+            "[STATE] ConnectionMonitor: is_active=True, attempt=0 "
+            "(caller=_manual_reconnect)")
 
         self._attempt_reconnect()
 
@@ -696,15 +814,32 @@ class BacktestApp:
             return
 
     def _attempt_reconnect(self):
-        """Try to re-login and reconnect to quote service."""
+        """Try to re-login and reconnect to quote service.
+
+        Bug B: each attempt MUST call ``SKQuoteLib_LeaveMonitor()`` +
+        ``SKCenterLib_LogOut()`` first (best-effort) so we start from a
+        clean COM state. Otherwise login+EnterMonitor stacks on top of a
+        broken session and the server may reach Quote (3002) without ever
+        sending Ready (3003) — exactly the zombie pattern seen in bot
+        session 0422.
+        """
         self._reconnect_timer_id = None
+        attempt_n = self._conn_monitor.attempt + 1  # number we'll attempt now
         if self._quote_connected:
+            _log_debug(
+                f"[RECONNECT] Attempt #{attempt_n} aborted — _quote_connected "
+                "is already True (likely reconnected via another path)")
             return  # already reconnected (e.g. by manual login)
 
         _log(f"嘗試重連 Attempting reconnect #{self._conn_monitor.attempt}")
+        _log_debug(
+            f"[RECONNECT] Attempt #{attempt_n} starting — calling LeaveMonitor "
+            "+ LogOut (cleanup) before fresh LoginSetQuote")
 
         try:
             if not _com_available:
+                _log_debug(
+                    f"[RECONNECT] Attempt #{attempt_n} aborted — _com_available=False")
                 self._schedule_reconnect()
                 return
 
@@ -713,51 +848,109 @@ class BacktestApp:
             password = self.login_pass_var.get().strip()
             if not user_id or not password:
                 _log("重連失敗 Reconnect failed: no credentials")
+                _log_debug(
+                    f"[RECONNECT] Attempt #{attempt_n} aborted — no credentials")
                 self._schedule_reconnect()
                 return
 
+            # ── Bug B: best-effort COM teardown before fresh login ──
+            # Both calls swallow errors — the prior session may already be
+            # half-torn-down and these are housekeeping, not gates.
+            try:
+                leave_code = skQ.SKQuoteLib_LeaveMonitor()
+                _log_debug(
+                    f"[RECONNECT] LeaveMonitor returned {leave_code}")
+            except Exception as e:
+                _log_debug(
+                    f"[RECONNECT] LeaveMonitor raised (ignored): "
+                    f"[{type(e).__name__}] {e}")
+            try:
+                logout_code = skC.SKCenterLib_LogOut(user_id)
+                _log_debug(
+                    f"[RECONNECT] LogOut returned {logout_code}")
+            except Exception as e:
+                _log_debug(
+                    f"[RECONNECT] LogOut raised (ignored): "
+                    f"[{type(e).__name__}] {e}")
+            self._logged_in = False
+            _log_debug(
+                f"[RECONNECT] Cleanup done — calling LoginSetQuote")
+
             code = skC.SKCenterLib_LoginSetQuote(user_id, password, "Y")
+            _log_debug(f"[RECONNECT] LoginSetQuote returned {code}")
             if code != 0 and code < 2000:
                 msg = skC.SKCenterLib_GetReturnCodeMessage(code)
                 _log(f"重連登入失敗 Reconnect login failed: {msg}")
+                _log_debug(
+                    f"[RECONNECT] Attempt #{attempt_n} FAILED at LoginSetQuote — "
+                    f"code={code} msg={msg}")
                 self._schedule_reconnect()
                 return
 
             self._logged_in = True
-            skR.SKReplyLib_ConnectByID(user_id)
-            skQ.SKQuoteLib_EnterMonitorLONG()
+            reply_code = skR.SKReplyLib_ConnectByID(user_id)
+            enter_code = skQ.SKQuoteLib_EnterMonitorLONG()
+            _log_debug(
+                f"[RECONNECT] ConnectByID returned {reply_code}, "
+                f"EnterMonitorLONG returned {enter_code}")
+            _log_debug(
+                f"[RECONNECT] Attempt #{attempt_n} waiting for Ready (3003)...")
 
             # Poll for connection (OnConnection callback will set _quote_connected)
             self.root.after(3000, self._check_reconnection)
 
         except Exception as e:
             _log(f"重連異常 Reconnect error: {e}")
+            _log_debug(
+                f"[RECONNECT] Attempt #{attempt_n} raised: "
+                f"[{type(e).__name__}] {e}")
             self._schedule_reconnect()
 
     def _check_reconnection(self):
         """Poll IsConnected after reconnect login attempt."""
+        attempt_n = self._conn_monitor.attempt
         if self._quote_connected:
+            _log_debug(
+                f"[RECONNECT] Attempt #{attempt_n} SUCCESS — Ready received "
+                "(handled by _on_reconnected via _drain_ui_queue)")
             return  # success, handled by _on_reconnected via _drain_ui_queue
         try:
             ic = skQ.SKQuoteLib_IsConnected()
+            _log_debug(
+                f"[RECONNECT] IsConnected()={ic} after 3s poll "
+                f"(attempt #{attempt_n})")
             if ic == 1:
-                self._quote_connected = True
+                self._set_quote_connected(True, "_check_reconnection(IsConnected==1)")
                 self.btn_api.config(state=tk.NORMAL)
                 self.btn_deploy.config(state=tk.NORMAL)
                 self.btn_login.config(state=tk.DISABLED)
                 self.btn_reconnect.config(state=tk.NORMAL)
                 self.status_var.set("已連線 Connected - Ready")
                 self.login_status_var.set("已連線 Connected")
+                _log_debug(
+                    f"[RECONNECT] Attempt #{attempt_n} SUCCESS — "
+                    "IsConnected==1, fallback path")
                 self._on_reconnected()
                 return
-        except Exception:
-            pass
+        except Exception as e:
+            _log_debug(
+                f"[RECONNECT] IsConnected() raised (ignored): "
+                f"[{type(e).__name__}] {e}")
         # Not connected yet — schedule next reconnect attempt
+        _log_debug(
+            f"[RECONNECT] Attempt #{attempt_n} FAILED — timed out waiting "
+            f"for Ready after 3s, scheduling next attempt")
         self._schedule_reconnect()
 
     def _on_reconnected(self):
         """Handle successful reconnection: re-subscribe ticks if live bot is running."""
         self._conn_monitor.on_connected()
+        _log_debug(
+            "[STATE] ConnectionMonitor: is_active=False, attempt=0 "
+            "(caller=_on_reconnected)")
+        # A successful Ready resets the Bug C warn ladder — any earlier
+        # transient IsConnected!=1 reads are irrelevant once we're back up.
+        self._warn_disconnect_count = 0
         if self._reconnect_timer_id:
             self.root.after_cancel(self._reconnect_timer_id)
             self._reconnect_timer_id = None
@@ -789,13 +982,22 @@ class BacktestApp:
         self._live_history_tick_count = 0
         self._live_stale_drops = 0
         self._live_runner.suppress_strategy = True
+        # Track when this RequestTicks fired so we can log latency to first tick
+        # (and detect zombie subscriptions where no tick arrives).
+        self._ticks_requested_at = time.time()
+        self._first_tick_after_request_logged = False
 
         try:
             result = skQ.SKQuoteLib_RequestTicks(0, com_symbol)
             code = result[0] if isinstance(result, (list, tuple)) else result
+            _log_debug(
+                f"[TICKS] RequestTicks({com_symbol}) returned {code} — "
+                f"subscription sent (retry={_retry})")
             if code != 0 and code >= 3000:
                 msg = skC.SKCenterLib_GetReturnCodeMessage(code)
                 self._live_log_msg(f"重新訂閱失敗 Resubscribe failed: {msg}", "status")
+                _log_debug(
+                    f"[TICKS] RequestTicks FAILED: code={code} msg={msg}")
                 retry_action = self._conn_monitor.should_retry_resubscribe(_retry)
                 if retry_action:
                     self._live_log_msg(retry_action.message, "status")
@@ -820,6 +1022,8 @@ class BacktestApp:
             self._drain_tick_queue()
         except Exception as e:
             self._live_log_msg(f"重新訂閱異常 Resubscribe error: {e}", "status")
+            _log_debug(
+                f"[TICKS] RequestTicks raised: [{type(e).__name__}] {e}")
 
     # ══════════════════════════════════════════════════════════════
     #  UI BUILD
@@ -861,6 +1065,17 @@ class BacktestApp:
         # Reconnection state
         self._conn_monitor = ConnectionMonitor()
         self._reconnect_timer_id = None
+        # Bug A: timer that fires if Ready (3003) doesn't arrive after Quote (3002)
+        self._quote_ready_timer_id = None
+        self._quote_intermediate_seen_at: float = 0.0
+        # Bug C: consecutive IsConnected()!=1 readings from the watchdog "warn"
+        # path. Two in a row (30s apart) before we force a disconnect — one
+        # transient bad read shouldn't bypass the resubscribe → reconnect ladder.
+        self._warn_disconnect_count = 0
+        # Track whether the first tick after the latest RequestTicks has
+        # arrived — used to log resubscribe latency / zombie subscriptions.
+        self._ticks_requested_at: float = 0.0
+        self._first_tick_after_request_logged: bool = False
         self._tick_watchdog = TickWatchdog()  # tick health monitoring
         self._live_poll_id = None  # root.after() id for cancellation
         self._live_warmup_mode: bool = False
@@ -2150,7 +2365,7 @@ class BacktestApp:
         try:
             ic = skQ.SKQuoteLib_IsConnected()
             if ic == 1:
-                self._quote_connected = True
+                self._set_quote_connected(True, "_check_connection(IsConnected==1)")
                 self.btn_api.config(state=tk.NORMAL)
                 self.btn_deploy.config(state=tk.NORMAL)
                 self.btn_login.config(state=tk.DISABLED)
@@ -4018,14 +4233,37 @@ class BacktestApp:
         """Delegate tick health check to TickWatchdog and act on the result."""
         wd = self._tick_watchdog
         wd.active = self._live_tick_active
+
+        # Zombie-subscription detection: RequestTicks returned OK but no
+        # tick has arrived. Spot it once per minute past the 60s mark so
+        # the debug log shows the gap explicitly (otherwise it just looks
+        # like a quiet market). Only log during open market hours.
+        if (self._live_tick_active
+                and self._ticks_requested_at
+                and not self._first_tick_after_request_logged
+                and is_market_open()):
+            since_req = time.time() - self._ticks_requested_at
+            if since_req > 60 and int(since_req) % 60 < 35:
+                _log_debug(
+                    f"[TICKS] WARNING: No ticks for {since_req:.0f}s after "
+                    "RequestTicks — possible zombie subscription")
+
         action = wd.check()
+
+        mins = wd.elapsed_minutes()
+        # Per-check telemetry: cheap to grep, lets us reconstruct the watchdog
+        # trajectory across a stale-tick incident from the debug log alone.
+        _log_debug(
+            f"[WATCHDOG] check: elapsed={mins}m action={action!r} "
+            f"active={wd.active} warn_disconnect_count={self._warn_disconnect_count}")
 
         if action is None:
             return
 
-        mins = wd.elapsed_minutes()
-
         if action == "session_resubscribe":
+            _log_debug(
+                f"[WATCHDOG] action=session_resubscribe — new session, "
+                "calling _resubscribe_ticks()")
             _log("Tick watchdog: session transition — resubscribing for new session")
             self._live_log_msg(
                 "新盤重新訂閱 New session — re-subscribing ticks", "status")
@@ -4037,6 +4275,9 @@ class BacktestApp:
             self._tick_watchdog.on_session_resubscribe()
 
         elif action == "reconnect":
+            _log_debug(
+                f"[WATCHDOG] action=reconnect — elapsed={mins}m > RECONNECT_TIMEOUT, "
+                "forcing _on_disconnected()")
             _log(f"Tick watchdog: no ticks for {mins}m, forcing full reconnect")
             self._live_log_msg(
                 f"強制重連 Force reconnect — no ticks for {mins}m", "status")
@@ -4047,6 +4288,9 @@ class BacktestApp:
                     self._on_disconnected()
 
         elif action == "resubscribe":
+            _log_debug(
+                f"[WATCHDOG] Entering resubscribe path "
+                f"(elapsed={mins}m > RESUBSCRIBE_TIMEOUT)")
             _log(f"Tick watchdog: no ticks for {mins}m, re-subscribing")
             self._live_log_msg(
                 f"重新訂閱 Re-subscribing ticks — no ticks for {mins}m", "status")
@@ -4056,14 +4300,49 @@ class BacktestApp:
             self._live_log_msg(
                 f"警告 No ticks for {mins}m — connection may be lost", "status")
             _log(f"Tick watchdog: no ticks for {mins}m")
-            # Check if COM connection is alive
+            _log_debug(
+                f"[WATCHDOG] action=warn — elapsed={mins}m > WARN_TIMEOUT, "
+                "probing IsConnected() (will require 2 consecutive bad reads "
+                "before forcing disconnect)")
+            # Bug C: the old code immediately called _on_disconnected() on any
+            # IsConnected()!=1 reading, bypassing the resubscribe→reconnect
+            # ladder TickWatchdog was designed to drive. The watchdog already
+            # escalates to "resubscribe" at 5min and "reconnect" at 10min;
+            # the IsConnected probe is only a tie-breaker. Require TWO
+            # consecutive bad reads (≈30s apart on the 30s schedule_status_update
+            # cadence) before short-circuiting to disconnect. One bad read alone
+            # is treated as noise and the ladder is allowed to continue.
             if _com_available:
                 try:
                     ic = skQ.SKQuoteLib_IsConnected()
-                    if ic != 1:
+                except Exception as e:
+                    ic = None
+                    _log_debug(
+                        f"[WATCHDOG] IsConnected() raised: "
+                        f"[{type(e).__name__}] {e} — treating as bad read")
+                if ic == 1:
+                    if self._warn_disconnect_count:
+                        _log_debug(
+                            f"[WATCHDOG] IsConnected()=1 — resetting "
+                            f"warn_disconnect_count "
+                            f"(was {self._warn_disconnect_count})")
+                    self._warn_disconnect_count = 0
+                else:
+                    self._warn_disconnect_count += 1
+                    _log_debug(
+                        f"[WATCHDOG] IsConnected()={ic} — "
+                        f"warn_disconnect_count={self._warn_disconnect_count}/2")
+                    if self._warn_disconnect_count >= 2:
+                        _log_debug(
+                            f"[WATCHDOG] IsConnected()={ic} for 2 consecutive "
+                            "warn checks — forcing disconnect")
+                        self._warn_disconnect_count = 0
                         self._on_disconnected()
-                except Exception:
-                    self._on_disconnected()
+                    else:
+                        _log_debug(
+                            "[WATCHDOG] One bad IsConnected() read — "
+                            "deferring to watchdog ladder (will re-check "
+                            "in ~30s)")
 
     def _drain_tick_queue(self):
         """Drain pending ticks from _tick_queue on the main thread.
@@ -4109,6 +4388,23 @@ class BacktestApp:
         if not is_history or not self._live_history_done:
             # Update watchdog: live ticks always, history ticks only during replay
             self._tick_watchdog.on_tick()
+            # A real tick means the COM session is alive — clear Bug C's
+            # warn-shortcut counter so a transient IsConnected glitch
+            # earlier doesn't carry over.
+            if self._warn_disconnect_count:
+                _log_debug(
+                    f"[WATCHDOG] real tick received — resetting "
+                    f"warn_disconnect_count (was {self._warn_disconnect_count})")
+                self._warn_disconnect_count = 0
+            # Log first tick after a RequestTicks so we can spot zombie
+            # subscriptions (RequestTicks returned OK but no tick ever came).
+            if (self._ticks_requested_at
+                    and not self._first_tick_after_request_logged):
+                self._first_tick_after_request_logged = True
+                latency = time.time() - self._ticks_requested_at
+                _log_debug(
+                    f"[TICKS] First tick received after resubscription "
+                    f"({latency:.2f}s since RequestTicks)")
 
         # Convert SK date/time integers to datetime FIRST — we need the
         # timestamp for the staleness check below (issue #50 fix).

--- a/src/evolution/__init__.py
+++ b/src/evolution/__init__.py
@@ -1,0 +1,1 @@
+"""Strategy Evolution Engine (SEE) — fitness scoring, gene pool, evaluator."""

--- a/src/evolution/evaluator.py
+++ b/src/evolution/evaluator.py
@@ -5,12 +5,22 @@ Two-phase evaluation:
 * ``screen`` — quick 30-day in-sample backtest. Cheap, used to filter
   obvious losers from a large mutation batch before paying for the full
   evaluation. Tagged with the Flash AI tier so any downstream AI scoring
-  picks the cheap model.
+  picks the cheap model. Reports are NOT persisted (screen is a throw-
+  away pass over many candidates).
 
 * ``deep`` — full evaluation: in-sample composite on a 3-month window
   plus walk-forward fitness on the next 3-month out-of-sample window.
   Tagged with the Pro AI tier. Walk-forward fitness is the number that
   drives pool promotion (in-sample composite overfits trivially).
+  Reports ARE persisted to ``data/daily-reports/`` so deep evaluations
+  surface in the existing daily-report UI exactly like manual backtests.
+
+Both phases run the backtest engine, then route the trades through
+:func:`src.daily_report.report_generator.generate_report_from_backtest`
+so regime classification (ADX/ATR/EMA labels) comes from the existing
+classifier rather than an evolution-private heuristic. Fitness is then
+computed from those daily-report dicts via
+:func:`src.evolution.fitness.compute_fitness_from_reports`.
 
 Anti-overfitting: each strategy can additionally be checked for
 parameter robustness via Monte Carlo perturbation (±10% on numeric
@@ -29,8 +39,13 @@ from typing import Any
 from ..ai.chat_client import PROVIDER_GOOGLE, model_for_tier
 from ..backtest.engine import BacktestEngine
 from ..ai.code_sandbox import load_strategy_from_source
+from ..daily_report.report_generator import generate_report_from_backtest
 from ..market_data.models import Bar
-from .fitness import FitnessResult, compute_fitness
+from .fitness import (
+    FitnessResult,
+    compute_fitness,
+    compute_fitness_from_reports,
+)
 
 
 # Days of bars used for the cheap "screen" pass. 30 calendar days is
@@ -56,7 +71,12 @@ CALL_SITE_DEEP = "evolution_deep"
 
 @dataclass
 class EvalResult:
-    """Per-strategy output of an evaluation pass."""
+    """Per-strategy output of an evaluation pass.
+
+    ``reports`` is the list of daily-report dicts produced by
+    :func:`generate_report_from_backtest`. Persisting these to disk
+    (deep phase default) makes evolution-driven backtests visible in
+    the same ``data/daily-reports/`` UI as manual ones."""
     name: str
     source_code: str
     fitness: FitnessResult
@@ -70,6 +90,8 @@ class EvalResult:
     phase: str = "screen"
     ai_tier: str = "light"
     ai_model_hint: str | None = None
+    reports: list[dict] | None = None
+    walkforward_reports: list[dict] | None = None
 
 
 def _slice_bars_by_date(
@@ -196,6 +218,48 @@ def _run_backtest(
     return engine.run(bars)
 
 
+def _ohlc_arrays(bars: list[Bar]) -> tuple[list[int], list[int], list[int]]:
+    """Materialize the highs/lows/closes arrays the regime classifier
+    expects. Pulled out so the evaluator never silently passes None
+    where the daily-report pipeline expects real data."""
+    return ([b.high for b in bars],
+            [b.low for b in bars],
+            [b.close for b in bars])
+
+
+def _backtest_with_reports(
+    strategy_cls: type,
+    bars: list[Bar],
+    name: str,
+    point_value: int,
+    fill_mode: str,
+    save_reports: bool,
+    param_overrides: dict[str, Any] | None = None,
+) -> tuple[Any, list[dict]]:
+    """Run a backtest AND route the trades through the daily-report
+    pipeline so each evaluation produces the same artifact shape as a
+    manual backtest. Returns ``(BacktestResult, list[report_dict])``.
+
+    ``save_reports=True`` persists each daily JSON to
+    ``data/daily-reports/`` (deep phase default); screen-phase calls
+    pass ``False`` to keep the throwaway pass cheap.
+    """
+    result = _run_backtest(strategy_cls, bars, point_value, fill_mode,
+                           param_overrides)
+    highs, lows, closes = _ohlc_arrays(bars)
+    reports = generate_report_from_backtest(
+        trades=result.trades,
+        equity_curve=result.equity_curve,
+        bars_highs=highs,
+        bars_lows=lows,
+        bars_closes=closes,
+        strategy_name=name,
+        point_value=point_value,
+        save=save_reports,
+    )
+    return result, reports
+
+
 def _bar_period(bars: list[Bar]) -> tuple[str, str] | None:
     if not bars:
         return None
@@ -266,12 +330,17 @@ def evaluate_screen(
     point_value: int = 200,
     fill_mode: str = "on_close",
     days: int = SCREEN_DAYS,
+    save_reports: bool = False,
 ) -> list[EvalResult]:
-    """Cheap pass: instantiate, run a 30-day in-sample backtest, score.
+    """Cheap pass: 30-day in-sample backtest, regime-aware fitness, no
+    persistence by default.
 
+    Each strategy is run through the same daily-report pipeline used by
+    manual backtests so regime scoring uses the real ADX/ATR labels.
     ``strategies`` is a list of ``(name, source_code)`` pairs. Failures
     (validation, runtime) are captured as ``EvalResult.error`` rather
-    than raised — one bad mutation shouldn't kill the batch."""
+    than raised — one bad mutation shouldn't kill the batch.
+    """
     window = _last_n_days(bars, days)
     period = _bar_period(window)
     out: list[EvalResult] = []
@@ -279,8 +348,10 @@ def evaluate_screen(
     for name, source in strategies:
         try:
             cls = load_strategy_from_source(source)
-            result = _run_backtest(cls, window, point_value, fill_mode)
-            fit = compute_fitness(result)
+            _, reports = _backtest_with_reports(
+                cls, window, name, point_value, fill_mode, save_reports,
+            )
+            fit = compute_fitness_from_reports(reports)
             out.append(EvalResult(
                 name=name,
                 source_code=source,
@@ -290,6 +361,7 @@ def evaluate_screen(
                 phase="screen",
                 ai_tier="light",
                 ai_model_hint=_ai_hint("light"),
+                reports=reports,
             ))
         except Exception as e:
             out.append(EvalResult(
@@ -312,10 +384,18 @@ def evaluate_deep(
     train_days: int = DEEP_TRAIN_DAYS,
     test_days: int = DEEP_TEST_DAYS,
     monte_carlo: bool = True,
+    save_reports: bool = True,
 ) -> list[EvalResult]:
     """Full pass: 3-month in-sample + 3-month walk-forward + (optional)
     Monte Carlo robustness. ``walkforward_fitness`` on the returned
-    EvalResult is the number that should drive pool promotion."""
+    EvalResult is the number that should drive pool promotion.
+
+    Daily reports for both windows are persisted to
+    ``data/daily-reports/`` by default so deep evaluations show up in
+    the existing report UI alongside manual backtests. Pass
+    ``save_reports=False`` to suppress (e.g. when sweeping a large
+    candidate batch you don't want cluttering the report directory).
+    """
     train, test = _split_train_test(bars, train_days, test_days)
     train_period = _bar_period(train)
     test_period = _bar_period(test)
@@ -325,15 +405,22 @@ def evaluate_deep(
         try:
             cls = load_strategy_from_source(source)
 
-            train_result = _run_backtest(cls, train, point_value, fill_mode)
-            train_fit = compute_fitness(train_result)
+            _, train_reports = _backtest_with_reports(
+                cls, train, name, point_value, fill_mode, save_reports,
+            )
+            train_fit = compute_fitness_from_reports(train_reports)
 
-            test_result = _run_backtest(cls, test, point_value, fill_mode)
-            test_fit = compute_fitness(test_result)
+            _, test_reports = _backtest_with_reports(
+                cls, test, name, point_value, fill_mode, save_reports,
+            )
+            test_fit = compute_fitness_from_reports(test_reports)
 
             fragile = False
             mc_var = 0.0
             if monte_carlo:
+                # MC stays on direct compute_fitness — perturbed
+                # backtests are throw-away noise; persisting their
+                # reports would clutter the data directory.
                 _, mc_var = monte_carlo_robustness(
                     cls, train, point_value, fill_mode,
                 )
@@ -352,6 +439,8 @@ def evaluate_deep(
                 phase="deep",
                 ai_tier="heavy",
                 ai_model_hint=_ai_hint("heavy"),
+                reports=train_reports,
+                walkforward_reports=test_reports,
             ))
         except Exception as e:
             out.append(EvalResult(

--- a/src/evolution/evaluator.py
+++ b/src/evolution/evaluator.py
@@ -1,0 +1,369 @@
+"""Batch backtest evaluator for the Strategy Evolution Engine.
+
+Two-phase evaluation:
+
+* ``screen`` — quick 30-day in-sample backtest. Cheap, used to filter
+  obvious losers from a large mutation batch before paying for the full
+  evaluation. Tagged with the Flash AI tier so any downstream AI scoring
+  picks the cheap model.
+
+* ``deep`` — full evaluation: in-sample composite on a 3-month window
+  plus walk-forward fitness on the next 3-month out-of-sample window.
+  Tagged with the Pro AI tier. Walk-forward fitness is the number that
+  drives pool promotion (in-sample composite overfits trivially).
+
+Anti-overfitting: each strategy can additionally be checked for
+parameter robustness via Monte Carlo perturbation (±10% on numeric
+``__init__`` defaults; >30% fitness variance flags the strategy as
+fragile).
+"""
+
+from __future__ import annotations
+
+import inspect
+import random
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import Any
+
+from ..ai.chat_client import PROVIDER_GOOGLE, model_for_tier
+from ..backtest.engine import BacktestEngine
+from ..ai.code_sandbox import load_strategy_from_source
+from ..market_data.models import Bar
+from .fitness import FitnessResult, compute_fitness
+
+
+# Days of bars used for the cheap "screen" pass. 30 calendar days is
+# enough for a few dozen H4 trades or hundreds of 1-min trades —
+# plenty to filter out broken strategies but cheap to run.
+SCREEN_DAYS = 30
+# In-sample window for the deep pass.
+DEEP_TRAIN_DAYS = 90
+# Out-of-sample (walk-forward) window for the deep pass.
+DEEP_TEST_DAYS = 90
+
+# Monte Carlo robustness check.
+MC_PERTURBATION = 0.10   # ±10%
+MC_TRIALS = 3
+MC_FRAGILE_VARIANCE = 0.30   # composite variance > this → flagged fragile
+
+# Sentinel call_site values — match the conventions used by
+# ``src/ai/chat_client.py::_log_token_usage`` so AI usage attribution
+# downstream lines up with the screen / deep phases.
+CALL_SITE_SCREEN = "evolution_screen"
+CALL_SITE_DEEP = "evolution_deep"
+
+
+@dataclass
+class EvalResult:
+    """Per-strategy output of an evaluation pass."""
+    name: str
+    source_code: str
+    fitness: FitnessResult
+    walkforward_fitness: float = 0.0
+    walkforward_metrics: dict[str, Any] | None = None
+    train_period: tuple[str, str] | None = None
+    test_period: tuple[str, str] | None = None
+    fragile: bool = False
+    mc_variance: float = 0.0
+    error: str | None = None
+    phase: str = "screen"
+    ai_tier: str = "light"
+    ai_model_hint: str | None = None
+
+
+def _slice_bars_by_date(
+    bars: list[Bar],
+    start: Any | None = None,
+    end: Any | None = None,
+) -> list[Bar]:
+    """Return bars whose ``dt`` falls in ``[start, end)``. ``None`` on
+    either side means open-ended on that side."""
+    if not bars:
+        return []
+    out = bars
+    if start is not None:
+        out = [b for b in out if b.dt >= start]
+    if end is not None:
+        out = [b for b in out if b.dt < end]
+    return out
+
+
+def _last_n_days(bars: list[Bar], days: int) -> list[Bar]:
+    """Tail slice of bars covering approximately the last ``days`` of
+    real time. Computed off the last bar's timestamp so test data with
+    an arbitrary date range still produces a sensible window."""
+    if not bars:
+        return []
+    cutoff = bars[-1].dt - timedelta(days=days)
+    return [b for b in bars if b.dt >= cutoff]
+
+
+def _split_train_test(
+    bars: list[Bar],
+    train_days: int,
+    test_days: int,
+) -> tuple[list[Bar], list[Bar]]:
+    """Walk-forward split anchored at the END of ``bars``: most recent
+    ``test_days`` is the test window, the ``train_days`` immediately
+    before it is the training (in-sample) window. Older bars are
+    discarded — they're not the period we want to evaluate on."""
+    if not bars:
+        return [], []
+    end = bars[-1].dt
+    test_start = end - timedelta(days=test_days)
+    train_start = test_start - timedelta(days=train_days)
+    train = _slice_bars_by_date(bars, train_start, test_start)
+    test = _slice_bars_by_date(bars, test_start, None)
+    return train, test
+
+
+def _instantiate(
+    strategy_cls: type,
+    param_overrides: dict[str, Any] | None = None,
+) -> Any:
+    """Instantiate a strategy with optional parameter overrides.
+
+    Strategies have varied ``__init__`` signatures (some take no args,
+    some take a dict, most take individual numeric kwargs). We try the
+    most common shapes in turn and let the strategy raise if none fit.
+    """
+    overrides = param_overrides or {}
+    try:
+        return strategy_cls(**overrides)
+    except TypeError:
+        # Fall back to no-args (used by AbstractStrategy-derived classes
+        # that take a config dict instead of kwargs).
+        if not overrides:
+            return strategy_cls()
+        raise
+
+
+def _numeric_param_defaults(strategy_cls: type) -> dict[str, float]:
+    """Pull numeric defaults from the strategy's ``__init__`` for MC
+    perturbation. Booleans are excluded — they're integers in Python
+    but not numeric in any meaningful sense for ±10%."""
+    out: dict[str, float] = {}
+    try:
+        sig = inspect.signature(strategy_cls.__init__)
+    except (TypeError, ValueError):
+        return out
+    for name, p in sig.parameters.items():
+        if name == "self":
+            continue
+        if p.default is inspect.Parameter.empty:
+            continue
+        if isinstance(p.default, bool):
+            continue
+        if isinstance(p.default, (int, float)):
+            out[name] = float(p.default)
+    return out
+
+
+def _perturb(
+    defaults: dict[str, float],
+    rng: random.Random,
+    pct: float = MC_PERTURBATION,
+) -> dict[str, Any]:
+    """Return a new dict with each default jittered by ±``pct``. Values
+    that started as ints stay ints (integer periods like SMA(20) are
+    nonsensical as 19.7); floats stay floats."""
+    out: dict[str, Any] = {}
+    for k, v in defaults.items():
+        delta = rng.uniform(-pct, pct)
+        new = v * (1.0 + delta)
+        if float(v).is_integer():
+            new = max(1, int(round(new)))
+        out[k] = new
+    return out
+
+
+def _run_backtest(
+    strategy_cls: type,
+    bars: list[Bar],
+    point_value: int = 200,
+    fill_mode: str = "on_close",
+    param_overrides: dict[str, Any] | None = None,
+) -> Any:
+    """Single backtest run. Returns the engine's BacktestResult."""
+    strategy = _instantiate(strategy_cls, param_overrides)
+    engine = BacktestEngine(
+        strategy,
+        point_value=point_value,
+        max_bars=max(5000, len(bars)),
+        fill_mode=fill_mode,
+    )
+    return engine.run(bars)
+
+
+def _bar_period(bars: list[Bar]) -> tuple[str, str] | None:
+    if not bars:
+        return None
+    fmt = "%Y-%m-%d"
+    return (bars[0].dt.strftime(fmt), bars[-1].dt.strftime(fmt))
+
+
+def _ai_hint(tier: str) -> str | None:
+    """Return the Google model name we'd prefer for the given tier so
+    downstream AI calls (e.g. AI-driven mutation review) line up with
+    the evaluator's screen/deep cost split. Returns ``None`` for
+    non-Google providers — caller falls back to user default."""
+    return model_for_tier(PROVIDER_GOOGLE, tier)
+
+
+def monte_carlo_robustness(
+    strategy_cls: type,
+    bars: list[Bar],
+    point_value: int = 200,
+    fill_mode: str = "on_close",
+    trials: int = MC_TRIALS,
+    seed: int | None = 42,
+) -> tuple[float, float]:
+    """Run ``trials`` backtests with ±10% jittered numeric params.
+
+    Returns ``(mean_composite, variance_pct)`` — variance_pct is the
+    coefficient of variation (std/|mean|). Caller flags as fragile when
+    ``variance_pct > MC_FRAGILE_VARIANCE``.
+    """
+    defaults = _numeric_param_defaults(strategy_cls)
+    if not defaults or trials < 2:
+        # No numeric params or not enough trials to compute variance —
+        # robustness check is a no-op, reported as 0 variance.
+        return 0.0, 0.0
+
+    rng = random.Random(seed)
+    composites: list[float] = []
+    for _ in range(trials):
+        overrides = _perturb(defaults, rng)
+        try:
+            result = _run_backtest(
+                strategy_cls, bars,
+                point_value=point_value,
+                fill_mode=fill_mode,
+                param_overrides=overrides,
+            )
+            fit = compute_fitness(result)
+            composites.append(fit.composite)
+        except Exception:
+            # A perturbation that crashes the strategy IS fragility —
+            # record a zero so it drags the mean down and inflates variance.
+            composites.append(0.0)
+
+    n = len(composites)
+    mean = sum(composites) / n if n else 0.0
+    if mean == 0:
+        # All trials zero → no signal but no variance to report either.
+        return 0.0, 0.0
+    var = sum((c - mean) ** 2 for c in composites) / n
+    std = var ** 0.5
+    cv = std / abs(mean)
+    return mean, cv
+
+
+def evaluate_screen(
+    strategies: list[tuple[str, str]],
+    bars: list[Bar],
+    point_value: int = 200,
+    fill_mode: str = "on_close",
+    days: int = SCREEN_DAYS,
+) -> list[EvalResult]:
+    """Cheap pass: instantiate, run a 30-day in-sample backtest, score.
+
+    ``strategies`` is a list of ``(name, source_code)`` pairs. Failures
+    (validation, runtime) are captured as ``EvalResult.error`` rather
+    than raised — one bad mutation shouldn't kill the batch."""
+    window = _last_n_days(bars, days)
+    period = _bar_period(window)
+    out: list[EvalResult] = []
+
+    for name, source in strategies:
+        try:
+            cls = load_strategy_from_source(source)
+            result = _run_backtest(cls, window, point_value, fill_mode)
+            fit = compute_fitness(result)
+            out.append(EvalResult(
+                name=name,
+                source_code=source,
+                fitness=fit,
+                walkforward_fitness=0.0,
+                train_period=period,
+                phase="screen",
+                ai_tier="light",
+                ai_model_hint=_ai_hint("light"),
+            ))
+        except Exception as e:
+            out.append(EvalResult(
+                name=name,
+                source_code=source,
+                fitness=compute_fitness({"trades": [], "metrics": None}),
+                error=f"{type(e).__name__}: {e}",
+                phase="screen",
+                ai_tier="light",
+                ai_model_hint=_ai_hint("light"),
+            ))
+    return out
+
+
+def evaluate_deep(
+    strategies: list[tuple[str, str]],
+    bars: list[Bar],
+    point_value: int = 200,
+    fill_mode: str = "on_close",
+    train_days: int = DEEP_TRAIN_DAYS,
+    test_days: int = DEEP_TEST_DAYS,
+    monte_carlo: bool = True,
+) -> list[EvalResult]:
+    """Full pass: 3-month in-sample + 3-month walk-forward + (optional)
+    Monte Carlo robustness. ``walkforward_fitness`` on the returned
+    EvalResult is the number that should drive pool promotion."""
+    train, test = _split_train_test(bars, train_days, test_days)
+    train_period = _bar_period(train)
+    test_period = _bar_period(test)
+    out: list[EvalResult] = []
+
+    for name, source in strategies:
+        try:
+            cls = load_strategy_from_source(source)
+
+            train_result = _run_backtest(cls, train, point_value, fill_mode)
+            train_fit = compute_fitness(train_result)
+
+            test_result = _run_backtest(cls, test, point_value, fill_mode)
+            test_fit = compute_fitness(test_result)
+
+            fragile = False
+            mc_var = 0.0
+            if monte_carlo:
+                _, mc_var = monte_carlo_robustness(
+                    cls, train, point_value, fill_mode,
+                )
+                fragile = mc_var > MC_FRAGILE_VARIANCE
+
+            out.append(EvalResult(
+                name=name,
+                source_code=source,
+                fitness=train_fit,
+                walkforward_fitness=test_fit.composite,
+                walkforward_metrics=test_fit.to_dict(),
+                train_period=train_period,
+                test_period=test_period,
+                fragile=fragile,
+                mc_variance=mc_var,
+                phase="deep",
+                ai_tier="heavy",
+                ai_model_hint=_ai_hint("heavy"),
+            ))
+        except Exception as e:
+            out.append(EvalResult(
+                name=name,
+                source_code=source,
+                fitness=compute_fitness({"trades": [], "metrics": None}),
+                walkforward_fitness=0.0,
+                train_period=train_period,
+                test_period=test_period,
+                error=f"{type(e).__name__}: {e}",
+                phase="deep",
+                ai_tier="heavy",
+                ai_model_hint=_ai_hint("heavy"),
+            ))
+    return out

--- a/src/evolution/evaluator.py
+++ b/src/evolution/evaluator.py
@@ -15,7 +15,17 @@ Two-phase evaluation:
   Reports ARE persisted to ``data/daily-reports/`` so deep evaluations
   surface in the existing daily-report UI exactly like manual backtests.
 
-Both phases run the backtest engine, then route the trades through
+* ``paper_trading`` scoring — once a strategy is promoted to a paper
+  bot, :func:`score_paper_trading_results` and :func:`score_paper_session`
+  ingest its accumulated trades (from ``broker.trades`` or the bot's
+  ``session.json``) and update the pool's ``paper_trading_*`` columns.
+  Paper trades come from the same ``SimulatedBroker`` as backtest
+  trades, so the fitness math is identical — only the ``source`` audit
+  tag and the destination pool columns differ. Promotion to ``live`` is
+  gated by :func:`src.evolution.pool.eligible_for_live`, which weighs
+  the paper-trading composite ahead of walkforward.
+
+Both backtest phases route the trades through
 :func:`src.daily_report.report_generator.generate_report_from_backtest`
 so regime classification (ADX/ATR/EMA labels) comes from the existing
 classifier rather than an evolution-private heuristic. Fitness is then
@@ -39,13 +49,18 @@ from typing import Any
 from ..ai.chat_client import PROVIDER_GOOGLE, model_for_tier
 from ..backtest.engine import BacktestEngine
 from ..ai.code_sandbox import load_strategy_from_source
+from ..backtest.broker import SimulatedBroker
 from ..daily_report.report_generator import generate_report_from_backtest
+from ..live.session_store import load_session
 from ..market_data.models import Bar
 from .fitness import (
     FitnessResult,
+    SOURCE_PAPER,
     compute_fitness,
     compute_fitness_from_reports,
+    compute_fitness_from_trades,
 )
+from .pool import StrategyPool
 
 
 # Days of bars used for the cheap "screen" pass. 30 calendar days is
@@ -456,3 +471,121 @@ def evaluate_deep(
                 ai_model_hint=_ai_hint("heavy"),
             ))
     return out
+
+
+# ---------------------------------------------------------------------------
+# Paper trading scoring
+# ---------------------------------------------------------------------------
+#
+# A strategy promoted to ``paper_trading`` status runs as a real live bot
+# (``LiveRunner.trading_mode == "paper"``). Trades accumulate in the
+# broker; every save snapshot lands in ``data/live/{symbol}_{bot}/session.json``
+# and per-session daily reports land in ``data/daily-reports/``.
+#
+# The scoring functions here read whichever format the caller has on hand
+# and update the pool's ``paper_trading_*`` columns. The fitness math
+# itself is identical to backtest scoring — only the ``source`` tag and
+# the pool column differ. See ``src.evolution.pool.eligible_for_live`` for
+# the live-promotion gate that consumes these scores.
+
+
+def score_paper_trading_results(
+    pool: StrategyPool,
+    strategy_id: str,
+    trades: list[Any],
+    equity_curve: list[int] | None = None,
+    period_start: str | None = None,
+    period_end: str | None = None,
+) -> FitnessResult:
+    """Score accumulated paper-trading trades and update the pool.
+
+    ``trades`` can be ``Trade`` dataclass instances (from
+    ``broker.trades``) or trade dicts (from a session JSON's
+    ``broker.trades`` list). The pool entry's
+    ``paper_trading_fitness`` / ``paper_trading_period_*`` /
+    ``paper_trading_trades`` columns are updated atomically.
+
+    Raises ``KeyError`` if ``strategy_id`` isn't in the pool.
+
+    The returned ``FitnessResult.source`` is ``"paper"`` so downstream
+    inspection can tell this score apart from the backtest one.
+    """
+    fit = compute_fitness_from_trades(
+        trades, equity_curve, source=SOURCE_PAPER,
+    )
+    pool.update_paper_trading_fitness(
+        id_=strategy_id,
+        fitness_dict=fit.to_dict(),
+        paper_trading_fitness=fit.composite,
+        period_start=period_start,
+        period_end=period_end,
+        n_trades=fit.total_trades,
+    )
+    return fit
+
+
+def _trades_from_session_dict(session: dict) -> tuple[list[Any], list[int], str | None]:
+    """Pull ``(trades, equity_curve, started_at)`` out of a session JSON.
+
+    Restores via :class:`SimulatedBroker.from_dict` so the trade list
+    matches the shape ``compute_fitness_from_trades`` accepts directly
+    (Trade dataclass instances with proper OrderSide enums). The
+    started_at timestamp doubles as the paper-trading period start when
+    the caller doesn't override it.
+    """
+    broker_data = session.get("broker") or {}
+    broker = SimulatedBroker.from_dict(broker_data)
+    started = session.get("started_at")
+    return list(broker.trades), list(broker.equity_curve), started
+
+
+def score_paper_session(
+    pool: StrategyPool,
+    strategy_id: str,
+    session_path: str,
+    period_end: str | None = None,
+) -> FitnessResult | None:
+    """Convenience wrapper: load a paper-bot ``session.json`` and score it.
+
+    Reads ``data/live/{symbol}_{bot_name}/session.json`` (the exact path
+    written by :meth:`src.live.live_runner.LiveRunner._auto_save_session`),
+    extracts the broker's accumulated trades + equity curve, and updates
+    the pool. The session's ``started_at`` timestamp is used as the
+    paper-trading period start unless the caller passes ``period_end``;
+    the period end defaults to the session's ``saved_at``.
+
+    Returns ``None`` (without touching the pool) when the session file
+    doesn't exist or is corrupt — paper sessions can be deleted or
+    rotated and the caller shouldn't see that as a hard error.
+
+    Refuses to score sessions where ``trading_mode != "paper"`` —
+    semi_auto / auto sessions carry real-money trades and should be
+    scored via a separate path that explicitly opts in to that data
+    (out of scope for Phase 1).
+    """
+    session = load_session(session_path)
+    if session is None:
+        return None
+    if session.get("trading_mode") not in ("paper", None):
+        # None handles old session files written before the
+        # trading_mode field existed. Real-money modes refuse here.
+        raise ValueError(
+            f"session at {session_path!r} has trading_mode="
+            f"{session.get('trading_mode')!r}, only 'paper' is supported"
+        )
+
+    trades, equity_curve, started_at = _trades_from_session_dict(session)
+    period_end = period_end or session.get("saved_at")
+    # Take just the date portion so the period columns are uniform with
+    # the backtest period_start / period_end format (YYYY-MM-DD).
+    started_date = started_at[:10] if started_at else None
+    end_date = period_end[:10] if period_end else None
+
+    return score_paper_trading_results(
+        pool=pool,
+        strategy_id=strategy_id,
+        trades=trades,
+        equity_curve=equity_curve,
+        period_start=started_date,
+        period_end=end_date,
+    )

--- a/src/evolution/fitness.py
+++ b/src/evolution/fitness.py
@@ -1,14 +1,27 @@
 """Multi-metric composite fitness scoring for strategy backtest results.
 
-Consumes the BacktestResult shape produced by ``src.backtest.engine``:
-``result.trades`` (list[Trade]), ``result.equity_curve`` (list[int],
-cumulative PnL), ``result.metrics`` (PerformanceMetrics).
+Two entry points consume the data structures that already exist in this
+codebase — no new shapes are invented:
 
-The composite score is a weighted, normalized combination of risk-adjusted
+* :func:`compute_fitness` consumes the ``BacktestResult`` shape produced
+  by :class:`src.backtest.engine.BacktestEngine` (``result.trades``,
+  ``result.equity_curve``, ``result.metrics``). Regime scoring uses a
+  per-trade price-direction proxy because ``BacktestResult`` has no
+  market-context attached.
+
+* :func:`compute_fitness_from_reports` is the canonical SEE entry point.
+  It consumes the daily-report dicts produced by
+  :func:`src.daily_report.report_generator.generate_report_from_backtest`
+  (the same JSONs persisted at ``data/daily-reports/YYYY-MM-DD.json``).
+  Regime scoring uses the real ADX/ATR/EMA labels emitted by
+  :func:`src.daily_report.regime_classifier.classify_regime`, mapped down
+  to bull / bear / sideways buckets.
+
+The composite is a weighted, normalized combination of risk-adjusted
 return, drawdown, profit factor, win rate, monthly consistency, and
-regime-balance metrics. Strategies with fewer than ``MIN_TRADES`` trades
-are gated to a composite of 0 — small samples can score well by luck and
-should not propagate through the gene pool.
+regime balance. Strategies with fewer than ``MIN_TRADES`` trades are
+gated to a composite of 0 — small samples score well by luck and should
+not propagate through the gene pool.
 """
 
 from __future__ import annotations
@@ -232,46 +245,50 @@ class FitnessResult:
         }
 
 
-def compute_fitness(
-    backtest_result: Any,
-    weights: dict[str, float] | None = None,
-) -> FitnessResult:
-    """Score a backtest result. Accepts either a ``BacktestResult`` instance
-    or a dict-like with keys ``trades``, ``equity_curve``, ``metrics``.
-
-    ``weights`` overrides ``DEFAULT_WEIGHTS`` (must contain every key).
-    """
-    w = weights if weights is not None else DEFAULT_WEIGHTS
-
-    # Accept both the engine's BacktestResult object and a plain dict —
-    # tests use the latter so they don't need to spin up the full engine.
-    if isinstance(backtest_result, dict):
-        trades = backtest_result.get("trades", [])
-        metrics = backtest_result.get("metrics")
+def _extract_metric_floats(metrics: Any) -> dict[str, float]:
+    """Pull the four scalar metrics fitness needs out of a
+    ``PerformanceMetrics`` instance OR a plain dict (the JSON shape used
+    by daily-report ``summary`` blocks)."""
+    if metrics is None:
+        return {"sharpe": 0.0, "profit_factor": 0.0,
+                "win_rate": 0.0, "max_drawdown_pct": 0.0}
+    if isinstance(metrics, dict):
+        get = metrics.get
     else:
-        trades = getattr(backtest_result, "trades", [])
-        metrics = getattr(backtest_result, "metrics", None)
+        get = lambda k, d=0.0: getattr(metrics, k, d)
+    return {
+        "sharpe": float(get("sharpe_ratio", 0.0) or 0.0),
+        "profit_factor": float(get("profit_factor", 0.0) or 0.0),
+        "win_rate": float(get("win_rate", 0.0) or 0.0),
+        "max_drawdown_pct": float(get("max_drawdown_pct", 0.0) or 0.0),
+    }
 
+
+def _compose(
+    trades: list[Any],
+    metrics: Any,
+    regimes: dict[str, float],
+    weights: dict[str, float],
+) -> FitnessResult:
+    """Shared assembly path. ``regimes`` is the pre-computed
+    bull/bear/sideways win-rate dict; how it was derived (naive proxy or
+    real ADX/ATR labels) is the caller's choice."""
     total_trades = len(trades)
-    sharpe = float(getattr(metrics, "sharpe_ratio", 0.0)) if metrics is not None else 0.0
-    profit_factor = float(getattr(metrics, "profit_factor", 0.0)) if metrics is not None else 0.0
-    win_rate = float(getattr(metrics, "win_rate", 0.0)) if metrics is not None else 0.0
-    max_dd_pct = float(getattr(metrics, "max_drawdown_pct", 0.0)) if metrics is not None else 0.0
+    scalars = _extract_metric_floats(metrics)
 
-    pnls = [float(getattr(t, "pnl", 0)) for t in trades]
+    pnls = [float(getattr(t, "pnl", 0) or 0) if not isinstance(t, dict)
+            else float(t.get("pnl", 0) or 0) for t in trades]
     sortino = sortino_ratio(pnls)
 
     monthly = _group_pnl_by_month(trades)
     consistency = consistency_score(monthly)
 
-    regimes = regime_scores(trades)
-
     raw = {
-        "sharpe": sharpe,
+        "sharpe": scalars["sharpe"],
         "sortino": sortino,
-        "profit_factor": profit_factor,
-        "max_drawdown_pct": max_dd_pct,
-        "win_rate": win_rate,
+        "profit_factor": scalars["profit_factor"],
+        "max_drawdown_pct": scalars["max_drawdown_pct"],
+        "win_rate": scalars["win_rate"],
         "consistency": consistency,
         "regime_bull": regimes["bull"],
         "regime_bear": regimes["bear"],
@@ -279,8 +296,7 @@ def compute_fitness(
     }
     normalized = _normalize(raw)
 
-    composite = sum(w[k] * normalized[k] for k in w)
-    composite = _clip01(composite)
+    composite = _clip01(sum(weights[k] * normalized[k] for k in weights))
 
     gated = total_trades < MIN_TRADES
     if gated:
@@ -288,11 +304,11 @@ def compute_fitness(
 
     return FitnessResult(
         composite=composite,
-        sharpe=sharpe,
+        sharpe=scalars["sharpe"],
         sortino=sortino,
-        max_drawdown_pct=max_dd_pct,
-        profit_factor=profit_factor,
-        win_rate=win_rate,
+        max_drawdown_pct=scalars["max_drawdown_pct"],
+        profit_factor=scalars["profit_factor"],
+        win_rate=scalars["win_rate"],
         consistency=consistency,
         regime_bull=regimes["bull"],
         regime_bear=regimes["bear"],
@@ -300,3 +316,146 @@ def compute_fitness(
         total_trades=total_trades,
         gated=gated,
     )
+
+
+# Map the 7 labels emitted by ``classify_regime`` down to the spec's three
+# buckets. ``high-volatility`` and ``low-volatility-chop`` are bucketed as
+# sideways because direction is undefined in those regimes — a strategy
+# that performs in chop without a directional bias is what we want to
+# reward as "sideways-capable".
+_LABEL_TO_REGIME: dict[str, str] = {
+    "trending-up": "bull",
+    "transitional-bullish": "bull",
+    "trending-down": "bear",
+    "transitional-bearish": "bear",
+    "range-bound": "sideways",
+    "low-volatility-chop": "sideways",
+    "high-volatility": "sideways",
+}
+
+
+def label_to_regime(label: str | None) -> str | None:
+    """Public mapping: ``classify_regime`` label → bull/bear/sideways.
+    Returns None for an unknown / missing label so the caller can decide
+    whether to fall back to the per-trade naive proxy."""
+    if not label:
+        return None
+    return _LABEL_TO_REGIME.get(label)
+
+
+def regime_scores_from_reports(reports: Iterable[dict]) -> dict[str, float]:
+    """Bucket trades by the regime label of the day they closed on, then
+    compute per-bucket win rate. Trades on days without a regime label
+    (insufficient bars for ADX) are skipped — they don't add evidence
+    either way. Buckets with no trades score 0.0 (same convention as the
+    naive ``regime_scores``).
+    """
+    buckets: dict[str, list[dict]] = {"bull": [], "bear": [], "sideways": []}
+    for report in reports:
+        regime_block = report.get("market_regime") or {}
+        bucket = label_to_regime(regime_block.get("label"))
+        if bucket is None:
+            continue
+        for t in report.get("trades", []) or []:
+            buckets[bucket].append(t)
+
+    out: dict[str, float] = {}
+    for regime, ts in buckets.items():
+        if not ts:
+            out[regime] = 0.0
+            continue
+        wins = sum(1 for t in ts if (t.get("pnl") or 0) > 0)
+        out[regime] = wins / len(ts)
+    return out
+
+
+def compute_fitness(
+    backtest_result: Any,
+    weights: dict[str, float] | None = None,
+) -> FitnessResult:
+    """Score a ``BacktestResult`` (or a ``{"trades":..., "metrics":...}``
+    dict). Regime scoring uses the per-trade naive proxy because no
+    market-context is attached.
+
+    For SEE evaluations, prefer :func:`compute_fitness_from_reports` —
+    it consumes the same daily-report dicts the rest of the pipeline
+    already produces and uses the real ADX/ATR regime labels.
+    """
+    w = weights if weights is not None else DEFAULT_WEIGHTS
+
+    if isinstance(backtest_result, dict):
+        trades = backtest_result.get("trades", [])
+        metrics = backtest_result.get("metrics")
+    else:
+        trades = getattr(backtest_result, "trades", [])
+        metrics = getattr(backtest_result, "metrics", None)
+
+    return _compose(trades, metrics, regime_scores(trades), w)
+
+
+class _TradeStub:
+    """Minimal Trade-shaped wrapper around a report's trade-dict so it
+    can be fed to :func:`src.backtest.metrics.calculate_metrics` and
+    the rest of the fitness pipeline without re-instantiating the
+    full :class:`src.backtest.broker.Trade` dataclass (which requires
+    an ``OrderSide`` enum that the JSON form has lost)."""
+    __slots__ = ("pnl", "entry_dt", "exit_dt", "entry_bar_index",
+                 "exit_bar_index", "entry_price", "exit_price")
+
+    def __init__(self, d: dict):
+        self.pnl = int(d.get("pnl") or 0)
+        self.entry_dt = d.get("entry_dt") or ""
+        self.exit_dt = d.get("exit_dt") or ""
+        self.entry_bar_index = int(d.get("entry_bar_index") or 0)
+        self.exit_bar_index = int(d.get("exit_bar_index") or 0)
+        self.entry_price = int(d.get("entry_price") or 0)
+        self.exit_price = int(d.get("exit_price") or 0)
+
+
+def compute_fitness_from_reports(
+    reports: list[dict],
+    weights: dict[str, float] | None = None,
+) -> FitnessResult:
+    """Score a strategy from its daily-report dicts.
+
+    ``reports`` is the list returned by
+    :func:`src.daily_report.report_generator.generate_report_from_backtest`
+    (or a list of JSONs read back from ``data/daily-reports/``). All
+    trades from all reports are concatenated, fresh aggregate
+    ``PerformanceMetrics`` are computed, and per-regime win rates use
+    the labels recorded on each report.
+
+    Falls back gracefully on the per-trade naive regime proxy when ALL
+    reports are missing regime data (e.g. backtests too short for ADX),
+    so this function never refuses to score for missing context.
+    """
+    w = weights if weights is not None else DEFAULT_WEIGHTS
+
+    # Lazy import: keeps fitness usable without the daily_report package
+    # imported at module load (e.g. minimal CI environments).
+    from src.backtest.metrics import calculate_metrics
+
+    all_trades: list[dict] = []
+    for r in reports:
+        for t in r.get("trades", []) or []:
+            all_trades.append(t)
+
+    # Build aggregate metrics from the concatenated trade-dicts. The
+    # report's per-day ``summary`` blocks can't be summed directly
+    # (Sharpe, PF, max_dd are non-additive), so we re-derive from a
+    # synthetic Trade list shaped to satisfy ``calculate_metrics``.
+    synthetic = [_TradeStub(t) for t in all_trades]
+    equity_curve: list[int] = []
+    cum = 0
+    for t in synthetic:
+        cum += int(t.pnl or 0)
+        equity_curve.append(cum)
+    metrics = calculate_metrics(synthetic, equity_curve, initial_balance=0)
+
+    # Real regime labels first; fall back to the per-trade proxy when
+    # NO report carries a label at all.
+    regimes = regime_scores_from_reports(reports)
+    if all(v == 0.0 for v in regimes.values()) and synthetic:
+        regimes = regime_scores(synthetic)
+
+    return _compose(synthetic, metrics, regimes, w)

--- a/src/evolution/fitness.py
+++ b/src/evolution/fitness.py
@@ -1,0 +1,302 @@
+"""Multi-metric composite fitness scoring for strategy backtest results.
+
+Consumes the BacktestResult shape produced by ``src.backtest.engine``:
+``result.trades`` (list[Trade]), ``result.equity_curve`` (list[int],
+cumulative PnL), ``result.metrics`` (PerformanceMetrics).
+
+The composite score is a weighted, normalized combination of risk-adjusted
+return, drawdown, profit factor, win rate, monthly consistency, and
+regime-balance metrics. Strategies with fewer than ``MIN_TRADES`` trades
+are gated to a composite of 0 — small samples can score well by luck and
+should not propagate through the gene pool.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Iterable
+
+# Minimum trades for the composite to be non-zero. Below this, sample
+# size is too small to distinguish signal from luck.
+MIN_TRADES = 30
+
+# Default weights — must sum to 1.0. Tuned to favor risk-adjusted return
+# while penalizing drawdown and rewarding regime robustness.
+DEFAULT_WEIGHTS: dict[str, float] = {
+    "sharpe": 0.20,
+    "sortino": 0.15,
+    "drawdown": 0.20,
+    "profit_factor": 0.15,
+    "win_rate": 0.10,
+    "consistency": 0.10,
+    "regime_balance": 0.10,
+}
+
+# Normalization caps — values beyond these saturate at 1.0.
+_SHARPE_CAP = 3.0
+_SORTINO_CAP = 3.0
+_PROFIT_FACTOR_CAP = 3.0   # PF=3 is excellent; Inf maps to 1.0
+_DRAWDOWN_CAP_PCT = 30.0   # 30% DD or worse → 0.0
+
+# Regime classification — each trade is bucketed by the price move during
+# its lifetime (exit_price vs entry_price). The threshold separates "trend"
+# from "sideways"; 1% is small enough that intraday noise doesn't dominate
+# but large enough that a directional bar move counts as a regime signal.
+_REGIME_TREND_PCT = 0.01
+
+
+def _clip01(x: float) -> float:
+    if x != x:  # NaN
+        return 0.0
+    if x < 0.0:
+        return 0.0
+    if x > 1.0:
+        return 1.0
+    return x
+
+
+def _parse_trade_dt(s: str) -> datetime | None:
+    """Trade.entry_dt / exit_dt are written by the engine as either
+    ``%Y-%m-%d %H:%M:%S`` (normal bars) or ``%Y-%m-%d %H:%M`` (force_close
+    fallback). Try both before giving up."""
+    if not s:
+        return None
+    for fmt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M"):
+        try:
+            return datetime.strptime(s, fmt)
+        except ValueError:
+            continue
+    return None
+
+
+def sortino_ratio(trade_pnls: list[float]) -> float:
+    """Sortino = mean / downside_std, scaled by sqrt(N) to match the
+    annualization style used by ``calculate_metrics`` for Sharpe.
+
+    Downside std uses only negative returns. If there are no negative
+    returns the strategy has no downside risk and we return a large
+    positive number capped by the caller's normalization."""
+    if len(trade_pnls) < 2:
+        return 0.0
+    mean = sum(trade_pnls) / len(trade_pnls)
+    downside = [r for r in trade_pnls if r < 0]
+    if not downside:
+        # No losses — return a strong but finite signal so downstream
+        # normalization treats it as max-good rather than infinity.
+        return _SORTINO_CAP * 2 if mean > 0 else 0.0
+    # Population std of downside returns vs mean of ALL returns. This is
+    # the standard Sortino convention (penalize drawdown, not symmetry).
+    variance = sum((r - mean) ** 2 for r in downside) / len(downside)
+    downside_std = math.sqrt(variance) if variance > 0 else 0.0
+    if downside_std == 0:
+        return 0.0
+    return (mean / downside_std) * math.sqrt(len(trade_pnls))
+
+
+def consistency_score(trade_pnls_by_month: dict[str, float]) -> float:
+    """Score in [0, 1] rewarding low std-dev relative to mean of monthly
+    PnL. A strategy that makes the same money every month scores 1.0;
+    one with wild swings around a small positive mean scores low.
+
+    Returns 0.0 when there's <2 months of data (no variance to measure).
+    """
+    monthly = list(trade_pnls_by_month.values())
+    if len(monthly) < 2:
+        return 0.0
+    mean = sum(monthly) / len(monthly)
+    if mean <= 0:
+        # Net-losing months on average — no consistency credit.
+        return 0.0
+    variance = sum((m - mean) ** 2 for m in monthly) / (len(monthly) - 1)
+    std = math.sqrt(variance) if variance > 0 else 0.0
+    if std == 0:
+        return 1.0
+    # Coefficient of variation: lower is better. CV=1 (std=mean) → ~0.5,
+    # CV=0 → 1.0, CV>>1 → near 0.
+    cv = std / mean
+    return _clip01(1.0 / (1.0 + cv))
+
+
+def _group_pnl_by_month(trades: Iterable[Any]) -> dict[str, float]:
+    """Bucket trade PnL by entry-month (YYYY-MM) string."""
+    out: dict[str, float] = {}
+    for t in trades:
+        dt = _parse_trade_dt(getattr(t, "entry_dt", "") or "")
+        if dt is None:
+            continue
+        key = dt.strftime("%Y-%m")
+        out[key] = out.get(key, 0.0) + float(t.pnl)
+    return out
+
+
+def _classify_trade_regime(trade: Any) -> str:
+    """Classify a single trade by the price direction during its lifetime.
+
+    This is a per-trade proxy for "what was the market doing while I was
+    holding this position?" — measured directly from entry_price/exit_price
+    on the trade itself rather than re-deriving from the bar feed (which
+    fitness doesn't have access to). Coarse but practical and stable.
+    """
+    entry = getattr(trade, "entry_price", 0)
+    exit_ = getattr(trade, "exit_price", 0)
+    if not entry or not exit_:
+        return "sideways"
+    pct = (exit_ - entry) / entry
+    if pct > _REGIME_TREND_PCT:
+        return "bull"
+    if pct < -_REGIME_TREND_PCT:
+        return "bear"
+    return "sideways"
+
+
+def regime_scores(trades: Iterable[Any]) -> dict[str, float]:
+    """Return per-regime win rates in [0, 1] for bull / bear / sideways.
+
+    A regime with no trades scores 0.0 — the strategy hasn't earned credit
+    for handling that regime. This is intentional: we want robustness
+    across regimes, not specialization in one.
+    """
+    buckets: dict[str, list[Any]] = {"bull": [], "bear": [], "sideways": []}
+    for t in trades:
+        buckets[_classify_trade_regime(t)].append(t)
+
+    out: dict[str, float] = {}
+    for regime, ts in buckets.items():
+        if not ts:
+            out[regime] = 0.0
+            continue
+        wins = sum(1 for t in ts if getattr(t, "pnl", 0) > 0)
+        out[regime] = wins / len(ts)
+    return out
+
+
+def _normalize(metrics: dict[str, float]) -> dict[str, float]:
+    """Normalize raw metrics to [0, 1] for weighted combination."""
+    sharpe = metrics["sharpe"]
+    sortino = metrics["sortino"]
+    pf = metrics["profit_factor"]
+    dd = metrics["max_drawdown_pct"]
+    wr = metrics["win_rate"]
+    consistency = metrics["consistency"]
+    regimes = (metrics["regime_bull"], metrics["regime_bear"],
+               metrics["regime_sideways"])
+
+    pf_capped = pf if math.isfinite(pf) else _PROFIT_FACTOR_CAP
+    return {
+        "sharpe": _clip01(sharpe / _SHARPE_CAP),
+        "sortino": _clip01(sortino / _SORTINO_CAP),
+        # PF=1 is breakeven → 0; PF=cap → 1.
+        "profit_factor": _clip01((pf_capped - 1.0) / (_PROFIT_FACTOR_CAP - 1.0)),
+        # 0% DD → 1.0; cap% DD or worse → 0.0.
+        "drawdown": _clip01(1.0 - dd / _DRAWDOWN_CAP_PCT),
+        "win_rate": _clip01(wr),
+        "consistency": _clip01(consistency),
+        # Reward the WORST regime — a strategy strong in bull only is
+        # penalized; one that's mediocre across all three is rewarded.
+        "regime_balance": _clip01(min(regimes)),
+    }
+
+
+@dataclass
+class FitnessResult:
+    """Bundle of raw metrics + composite score returned to callers."""
+    composite: float
+    sharpe: float
+    sortino: float
+    max_drawdown_pct: float
+    profit_factor: float
+    win_rate: float
+    consistency: float
+    regime_bull: float
+    regime_bear: float
+    regime_sideways: float
+    total_trades: int
+    gated: bool   # True when total_trades < MIN_TRADES (composite forced to 0)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "composite": self.composite,
+            "sharpe": self.sharpe,
+            "sortino": self.sortino,
+            "max_drawdown_pct": self.max_drawdown_pct,
+            "profit_factor": self.profit_factor,
+            "win_rate": self.win_rate,
+            "consistency": self.consistency,
+            "regime_bull": self.regime_bull,
+            "regime_bear": self.regime_bear,
+            "regime_sideways": self.regime_sideways,
+            "total_trades": self.total_trades,
+            "gated": self.gated,
+        }
+
+
+def compute_fitness(
+    backtest_result: Any,
+    weights: dict[str, float] | None = None,
+) -> FitnessResult:
+    """Score a backtest result. Accepts either a ``BacktestResult`` instance
+    or a dict-like with keys ``trades``, ``equity_curve``, ``metrics``.
+
+    ``weights`` overrides ``DEFAULT_WEIGHTS`` (must contain every key).
+    """
+    w = weights if weights is not None else DEFAULT_WEIGHTS
+
+    # Accept both the engine's BacktestResult object and a plain dict —
+    # tests use the latter so they don't need to spin up the full engine.
+    if isinstance(backtest_result, dict):
+        trades = backtest_result.get("trades", [])
+        metrics = backtest_result.get("metrics")
+    else:
+        trades = getattr(backtest_result, "trades", [])
+        metrics = getattr(backtest_result, "metrics", None)
+
+    total_trades = len(trades)
+    sharpe = float(getattr(metrics, "sharpe_ratio", 0.0)) if metrics is not None else 0.0
+    profit_factor = float(getattr(metrics, "profit_factor", 0.0)) if metrics is not None else 0.0
+    win_rate = float(getattr(metrics, "win_rate", 0.0)) if metrics is not None else 0.0
+    max_dd_pct = float(getattr(metrics, "max_drawdown_pct", 0.0)) if metrics is not None else 0.0
+
+    pnls = [float(getattr(t, "pnl", 0)) for t in trades]
+    sortino = sortino_ratio(pnls)
+
+    monthly = _group_pnl_by_month(trades)
+    consistency = consistency_score(monthly)
+
+    regimes = regime_scores(trades)
+
+    raw = {
+        "sharpe": sharpe,
+        "sortino": sortino,
+        "profit_factor": profit_factor,
+        "max_drawdown_pct": max_dd_pct,
+        "win_rate": win_rate,
+        "consistency": consistency,
+        "regime_bull": regimes["bull"],
+        "regime_bear": regimes["bear"],
+        "regime_sideways": regimes["sideways"],
+    }
+    normalized = _normalize(raw)
+
+    composite = sum(w[k] * normalized[k] for k in w)
+    composite = _clip01(composite)
+
+    gated = total_trades < MIN_TRADES
+    if gated:
+        composite = 0.0
+
+    return FitnessResult(
+        composite=composite,
+        sharpe=sharpe,
+        sortino=sortino,
+        max_drawdown_pct=max_dd_pct,
+        profit_factor=profit_factor,
+        win_rate=win_rate,
+        consistency=consistency,
+        regime_bull=regimes["bull"],
+        regime_bear=regimes["bear"],
+        regime_sideways=regimes["sideways"],
+        total_trades=total_trades,
+        gated=gated,
+    )

--- a/src/evolution/fitness.py
+++ b/src/evolution/fitness.py
@@ -212,6 +212,14 @@ def _normalize(metrics: dict[str, float]) -> dict[str, float]:
     }
 
 
+# Where a fitness result came from. Same math runs on both — the field
+# is purely audit metadata so the pool can tell paper from backtest
+# fitness when promotion decisions are made.
+SOURCE_BACKTEST = "backtest"
+SOURCE_PAPER = "paper"
+VALID_SOURCES = (SOURCE_BACKTEST, SOURCE_PAPER)
+
+
 @dataclass
 class FitnessResult:
     """Bundle of raw metrics + composite score returned to callers."""
@@ -227,6 +235,7 @@ class FitnessResult:
     regime_sideways: float
     total_trades: int
     gated: bool   # True when total_trades < MIN_TRADES (composite forced to 0)
+    source: str = SOURCE_BACKTEST
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -242,6 +251,7 @@ class FitnessResult:
             "regime_sideways": self.regime_sideways,
             "total_trades": self.total_trades,
             "gated": self.gated,
+            "source": self.source,
         }
 
 
@@ -269,10 +279,12 @@ def _compose(
     metrics: Any,
     regimes: dict[str, float],
     weights: dict[str, float],
+    source: str = SOURCE_BACKTEST,
 ) -> FitnessResult:
     """Shared assembly path. ``regimes`` is the pre-computed
     bull/bear/sideways win-rate dict; how it was derived (naive proxy or
-    real ADX/ATR labels) is the caller's choice."""
+    real ADX/ATR labels) is the caller's choice. ``source`` is audit
+    metadata stamped onto the result — same math runs either way."""
     total_trades = len(trades)
     scalars = _extract_metric_floats(metrics)
 
@@ -315,6 +327,7 @@ def _compose(
         regime_sideways=regimes["sideways"],
         total_trades=total_trades,
         gated=gated,
+        source=source,
     )
 
 
@@ -372,6 +385,7 @@ def regime_scores_from_reports(reports: Iterable[dict]) -> dict[str, float]:
 def compute_fitness(
     backtest_result: Any,
     weights: dict[str, float] | None = None,
+    source: str = SOURCE_BACKTEST,
 ) -> FitnessResult:
     """Score a ``BacktestResult`` (or a ``{"trades":..., "metrics":...}``
     dict). Regime scoring uses the per-trade naive proxy because no
@@ -390,7 +404,63 @@ def compute_fitness(
         trades = getattr(backtest_result, "trades", [])
         metrics = getattr(backtest_result, "metrics", None)
 
-    return _compose(trades, metrics, regime_scores(trades), w)
+    return _compose(trades, metrics, regime_scores(trades), w, source=source)
+
+
+def compute_fitness_from_trades(
+    trades: list[Any],
+    equity_curve: list[int] | None = None,
+    weights: dict[str, float] | None = None,
+    source: str = SOURCE_BACKTEST,
+) -> FitnessResult:
+    """Input-agnostic entry point: score a strategy from its raw trades.
+
+    Accepts ``Trade`` dataclass instances (what
+    ``SimulatedBroker.trades`` produces — same shape in backtest and
+    paper trading) OR trade dicts (what session.json / daily-report
+    JSONs store). The same math runs regardless of provenance; the
+    ``source`` field on the returned ``FitnessResult`` records where
+    the trades came from for audit purposes.
+
+    When ``equity_curve`` is omitted, it's rebuilt from the trades'
+    cumulative PnL — useful for paper-trading data loaded from session
+    JSON where the curve may be stale (e.g. position open at last save).
+
+    Regime scoring falls back to the per-trade naive proxy because raw
+    trades carry no market-context (no bar feed, no regime labels). For
+    paper trading, prefer scoring through the daily-report pipeline
+    when available — see :func:`compute_fitness_from_reports`.
+    """
+    if source not in VALID_SOURCES:
+        raise ValueError(
+            f"source must be one of {VALID_SOURCES!r}, got {source!r}"
+        )
+    w = weights if weights is not None else DEFAULT_WEIGHTS
+
+    # Normalize trade representation so the metrics engine sees a stable
+    # shape — dicts (from session JSON) get wrapped, dataclass instances
+    # pass through.
+    norm_trades: list[Any] = [
+        _TradeStub(t) if isinstance(t, dict) else t for t in trades
+    ]
+
+    # If the caller didn't supply an equity curve (or supplied an empty
+    # one), rebuild from cumulative PnL. Paper sessions sometimes save
+    # an equity curve mid-trade that doesn't include the last entry.
+    if not equity_curve:
+        equity_curve = []
+        cum = 0
+        for t in norm_trades:
+            cum += int(getattr(t, "pnl", 0) or 0)
+            equity_curve.append(cum)
+
+    # Lazy import — same rationale as compute_fitness_from_reports.
+    from src.backtest.metrics import calculate_metrics
+    metrics = calculate_metrics(norm_trades, equity_curve, initial_balance=0)
+
+    return _compose(
+        norm_trades, metrics, regime_scores(norm_trades), w, source=source,
+    )
 
 
 class _TradeStub:
@@ -415,20 +485,27 @@ class _TradeStub:
 def compute_fitness_from_reports(
     reports: list[dict],
     weights: dict[str, float] | None = None,
+    source: str = SOURCE_BACKTEST,
 ) -> FitnessResult:
     """Score a strategy from its daily-report dicts.
 
     ``reports`` is the list returned by
     :func:`src.daily_report.report_generator.generate_report_from_backtest`
-    (or a list of JSONs read back from ``data/daily-reports/``). All
-    trades from all reports are concatenated, fresh aggregate
-    ``PerformanceMetrics`` are computed, and per-regime win rates use
-    the labels recorded on each report.
+    or :func:`src.daily_report.report_generator.generate_session_report`
+    (live/paper sessions). Both shapes are identical — only the
+    ``source`` field on the returned ``FitnessResult`` differs.
 
-    Falls back gracefully on the per-trade naive regime proxy when ALL
-    reports are missing regime data (e.g. backtests too short for ADX),
-    so this function never refuses to score for missing context.
+    All trades from all reports are concatenated, fresh aggregate
+    ``PerformanceMetrics`` are computed, and per-regime win rates use
+    the labels recorded on each report. Falls back gracefully on the
+    per-trade naive regime proxy when ALL reports are missing regime
+    data (e.g. backtests too short for ADX), so this function never
+    refuses to score for missing context.
     """
+    if source not in VALID_SOURCES:
+        raise ValueError(
+            f"source must be one of {VALID_SOURCES!r}, got {source!r}"
+        )
     w = weights if weights is not None else DEFAULT_WEIGHTS
 
     # Lazy import: keeps fitness usable without the daily_report package
@@ -458,4 +535,4 @@ def compute_fitness_from_reports(
     if all(v == 0.0 for v in regimes.values()) and synthetic:
         regimes = regime_scores(synthetic)
 
-    return _compose(synthetic, metrics, regimes, w)
+    return _compose(synthetic, metrics, regimes, w, source=source)

--- a/src/evolution/notify.py
+++ b/src/evolution/notify.py
@@ -1,0 +1,301 @@
+"""Strategy-improvement notification glue between evolution and Discord.
+
+The evolution module ships the fitness math; this module wires it into
+the live daily-report pipeline so the bot can announce when a session
+has produced a new best composite score.
+
+Why a separate file:
+  - ``evaluator.py`` only scores paper sessions (the spec's promotion gate);
+    notification cares about any mode the user is actually running.
+  - ``fitness.py`` is pure metric math, no I/O.
+  - The baseline format is intentionally lightweight (one JSON file per
+    bot) so it has no schema migrations and no SQLite dependency. It
+    lives next to the bot's session.json under data/live/{symbol}_{bot}/.
+
+Public API (kept small for the GUI to call):
+  - :func:`score_session_for_notification` — score any-mode trades.
+  - :func:`detect_improvement` — compare against the persisted baseline,
+    return a verdict + optional new baseline to write.
+  - :func:`load_baseline` / :func:`save_baseline` — file I/O.
+  - :func:`check_and_notify_after_report` — single entry-point the GUI
+    hooks into ``_on_live_daily_report`` (does the scoring + comparison
+    + Discord send + baseline write).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone, timedelta
+from typing import Any, Callable
+
+from .fitness import (
+    FitnessResult,
+    SOURCE_BACKTEST,
+    SOURCE_PAPER,
+    compute_fitness_from_trades,
+)
+
+
+_TZ_TAIPEI = timezone(timedelta(hours=8))
+
+# Minimum delta (in composite units, 0–1 scale) over the running best
+# before we send a Discord "strategy improved" notification.  Chosen to
+# be coarse enough to ignore one-trade-luck noise on low-volume days
+# while still firing on real improvements.
+IMPROVEMENT_DELTA = 0.05
+
+# Filename used under each bot's directory.  Sits next to session.json
+# / decisions.csv / bars_1m_*.csv, no migration story needed.
+BASELINE_FILENAME = "evolution.json"
+
+
+@dataclass
+class Baseline:
+    """The "best composite so far" record persisted per bot.
+
+    Stored as JSON so it survives bot restarts and crashes; the schema
+    is small enough that we don't need a migration story.  Fields are
+    deliberately minimal — anything richer belongs in the StrategyPool.
+    """
+    best_composite: float
+    best_recorded_at: str   # ISO timestamp in Taipei
+    n_updates: int          # how many times we've written this file
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "best_composite": self.best_composite,
+            "best_recorded_at": self.best_recorded_at,
+            "n_updates": self.n_updates,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> "Baseline":
+        return cls(
+            best_composite=float(d.get("best_composite", 0.0) or 0.0),
+            best_recorded_at=str(d.get("best_recorded_at", "")),
+            n_updates=int(d.get("n_updates", 0) or 0),
+        )
+
+
+@dataclass
+class ImprovementVerdict:
+    """Result of comparing a fresh fitness to the persisted baseline.
+
+    ``send_notification=True`` means the GUI should fire the Discord
+    message; ``new_baseline`` is what should be written to disk after
+    the send (or ``None`` if the baseline shouldn't change).
+    """
+    send_notification: bool
+    fitness: FitnessResult
+    previous_best: float
+    delta: float
+    reason: str                       # human-readable rationale
+    new_baseline: Baseline | None     # write this if not None
+
+
+def _trading_mode_to_source(trading_mode: str | None) -> str:
+    """Map the GUI's trading_mode string to a fitness `source` tag.
+
+    Both "semi_auto" and "auto" run real market fills against a real
+    broker, so the trades are paper-equivalent for scoring purposes (no
+    look-ahead, real slippage).  Backtest is what comes from the
+    historical replay path — never the live pipeline.  When in doubt
+    default to paper so we don't accidentally tag live data as backtest.
+    """
+    if trading_mode == "backtest":
+        return SOURCE_BACKTEST
+    return SOURCE_PAPER
+
+
+def score_session_for_notification(
+    trades: list[Any],
+    equity_curve: list[int] | None = None,
+    trading_mode: str | None = None,
+) -> FitnessResult:
+    """Score accumulated trades without the paper-mode restriction.
+
+    The pool-aware :func:`src.evolution.evaluator.score_paper_session`
+    refuses ``trading_mode != "paper"`` because the spec's live-promotion
+    gate requires paper provenance.  For *notification*, we don't care:
+    the user wants a heads-up whenever the running strategy's composite
+    moves up, regardless of mode.  This wrapper bypasses the pool
+    machinery, calls the math directly, and stamps the source tag based
+    on the mode for downstream audit.
+    """
+    source = _trading_mode_to_source(trading_mode)
+    return compute_fitness_from_trades(
+        trades=trades,
+        equity_curve=equity_curve,
+        source=source,
+    )
+
+
+def baseline_path(bot_dir: str | os.PathLike) -> str:
+    """Return the path to a bot's baseline file."""
+    return os.path.join(str(bot_dir), BASELINE_FILENAME)
+
+
+def load_baseline(bot_dir: str | os.PathLike) -> Baseline | None:
+    """Return the persisted baseline or ``None`` on first run / corrupt file."""
+    path = baseline_path(bot_dir)
+    if not os.path.exists(path):
+        return None
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return Baseline.from_dict(json.load(f))
+    except (json.JSONDecodeError, OSError, ValueError):
+        # Corrupt baseline shouldn't crash the report pipeline.  Treat
+        # it as "first run" — the next improvement detected will rewrite
+        # the file with a clean record.
+        return None
+
+
+def save_baseline(bot_dir: str | os.PathLike, baseline: Baseline) -> None:
+    """Atomically replace the baseline file under ``bot_dir``.
+
+    Uses a temp file + os.replace so a crash mid-write can never leave
+    a corrupt baseline on disk (the old one stays valid until the new
+    one is fully flushed).
+    """
+    os.makedirs(str(bot_dir), exist_ok=True)
+    path = baseline_path(bot_dir)
+    tmp_path = path + ".tmp"
+    with open(tmp_path, "w", encoding="utf-8") as f:
+        json.dump(baseline.to_dict(), f, indent=2)
+        f.flush()
+        try:
+            os.fsync(f.fileno())
+        except OSError:
+            pass  # fsync isn't supported on every filesystem (e.g. some Windows shares)
+    os.replace(tmp_path, path)
+
+
+def detect_improvement(
+    fitness: FitnessResult,
+    previous: Baseline | None,
+    delta: float = IMPROVEMENT_DELTA,
+    now: datetime | None = None,
+) -> ImprovementVerdict:
+    """Compare a fresh fitness to the persisted baseline.
+
+    Rules:
+      * If ``fitness.gated`` (not enough trades) → no notification, no
+        baseline update.  The fitness machinery already zeroed the
+        composite so a write here would inflate the file's update count
+        without signal.
+      * If there's no previous baseline → notify (first-ever score is
+        the new best) and write the baseline.  This is the bootstrap
+        case: the user sees a first-run notification telling them what
+        the baseline now is.
+      * If composite − previous.best_composite > delta → notify + write.
+        Use strict > so identical scores don't spam notifications
+        (cheap idempotency on retries).
+      * Otherwise → no-op.
+    """
+    if now is None:
+        now = datetime.now(_TZ_TAIPEI)
+
+    if fitness.gated:
+        return ImprovementVerdict(
+            send_notification=False,
+            fitness=fitness,
+            previous_best=previous.best_composite if previous else 0.0,
+            delta=0.0,
+            reason=(
+                f"gated: only {fitness.total_trades} trades, "
+                f"minimum is enforced by fitness module"
+            ),
+            new_baseline=None,
+        )
+
+    ts = now.strftime("%Y-%m-%d %H:%M:%S")
+
+    if previous is None:
+        # First run for this bot.  Notify and persist the baseline so
+        # subsequent days have something to compare against.
+        return ImprovementVerdict(
+            send_notification=True,
+            fitness=fitness,
+            previous_best=0.0,
+            delta=fitness.composite,
+            reason="first scored session for this bot",
+            new_baseline=Baseline(
+                best_composite=fitness.composite,
+                best_recorded_at=ts,
+                n_updates=1,
+            ),
+        )
+
+    improvement = fitness.composite - previous.best_composite
+    if improvement > delta:
+        return ImprovementVerdict(
+            send_notification=True,
+            fitness=fitness,
+            previous_best=previous.best_composite,
+            delta=improvement,
+            reason=(
+                f"composite {fitness.composite:.3f} − "
+                f"{previous.best_composite:.3f} = {improvement:+.3f} "
+                f"(> {delta:.2f} threshold)"
+            ),
+            new_baseline=Baseline(
+                best_composite=fitness.composite,
+                best_recorded_at=ts,
+                n_updates=previous.n_updates + 1,
+            ),
+        )
+
+    return ImprovementVerdict(
+        send_notification=False,
+        fitness=fitness,
+        previous_best=previous.best_composite,
+        delta=improvement,
+        reason=(
+            f"no improvement: composite {fitness.composite:.3f}, "
+            f"previous best {previous.best_composite:.3f}, "
+            f"delta {improvement:+.3f} (≤ {delta:.2f} threshold)"
+        ),
+        new_baseline=None,
+    )
+
+
+def check_and_notify_after_report(
+    bot_dir: str | os.PathLike,
+    trades: list[Any],
+    equity_curve: list[int] | None,
+    trading_mode: str | None,
+    *,
+    send_notification: Callable[[ImprovementVerdict], None] | None = None,
+    delta: float = IMPROVEMENT_DELTA,
+) -> ImprovementVerdict:
+    """End-to-end glue: score → compare → optionally notify → persist.
+
+    ``send_notification`` is injected so this stays decoupled from the
+    Discord module — the GUI passes a callback that calls
+    :meth:`DiscordNotifier.strategy_improved`.  Tests can pass a spy.
+
+    Returns the verdict regardless of whether anything was sent, so the
+    caller can log the no-improvement path too if it wants.
+    """
+    fitness = score_session_for_notification(
+        trades=trades,
+        equity_curve=equity_curve,
+        trading_mode=trading_mode,
+    )
+    previous = load_baseline(bot_dir)
+    verdict = detect_improvement(fitness, previous, delta=delta)
+    if verdict.send_notification:
+        # Persist BEFORE the send so a Discord failure can't cost us
+        # the baseline write.  The send is fire-and-forget anyway.
+        if verdict.new_baseline is not None:
+            save_baseline(bot_dir, verdict.new_baseline)
+        if send_notification is not None:
+            try:
+                send_notification(verdict)
+            except Exception:
+                # Notification path is best-effort — never crash the
+                # daily-report pipeline because Discord hiccuped.
+                pass
+    return verdict

--- a/src/evolution/pool.py
+++ b/src/evolution/pool.py
@@ -1,0 +1,291 @@
+"""SQLite-backed strategy gene pool for the Evolution Engine.
+
+Each row is a candidate strategy with its source code, lineage pointer
+to the parent it was mutated from, both in-sample and walk-forward
+fitness, and a status that gates promotion through the pipeline:
+
+    candidate -> validated -> paper_trading -> live -> retired
+
+``walkforward_fitness`` is the number that actually drives promotion —
+in-sample composite is informational only (overfits trivially).
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import uuid
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterator
+
+
+# Allowed status values. A typo here would silently fail a SQL filter,
+# so we validate at the API boundary.
+STATUSES = (
+    "candidate",
+    "validated",
+    "paper_trading",
+    "live",
+    "retired",
+)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _new_id() -> str:
+    return str(uuid.uuid4())
+
+
+@dataclass
+class StrategyEntry:
+    """One row in the pool.
+
+    ``id`` and ``created_at`` / ``updated_at`` default-fill on insert if
+    left blank, so callers usually only supply ``name`` + ``source_code``
+    (+ optional parent_id / generation) when adding a fresh candidate.
+    """
+    name: str
+    source_code: str
+    id: str = field(default_factory=_new_id)
+    parent_id: str | None = None
+    generation: int = 0
+    fitness_composite: float = 0.0
+    fitness_json: str = "{}"
+    backtest_period_start: str | None = None
+    backtest_period_end: str | None = None
+    walkforward_period_start: str | None = None
+    walkforward_period_end: str | None = None
+    walkforward_fitness: float = 0.0
+    status: str = "candidate"
+    created_at: str = field(default_factory=_now_iso)
+    updated_at: str = field(default_factory=_now_iso)
+    notes: str = ""
+
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS strategies (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    source_code TEXT NOT NULL,
+    parent_id TEXT,
+    generation INTEGER NOT NULL DEFAULT 0,
+    fitness_composite REAL NOT NULL DEFAULT 0.0,
+    fitness_json TEXT NOT NULL DEFAULT '{}',
+    backtest_period_start TEXT,
+    backtest_period_end TEXT,
+    walkforward_period_start TEXT,
+    walkforward_period_end TEXT,
+    walkforward_fitness REAL NOT NULL DEFAULT 0.0,
+    status TEXT NOT NULL DEFAULT 'candidate',
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    notes TEXT NOT NULL DEFAULT ''
+);
+CREATE INDEX IF NOT EXISTS idx_strategies_status ON strategies(status);
+CREATE INDEX IF NOT EXISTS idx_strategies_walkforward
+    ON strategies(walkforward_fitness DESC);
+CREATE INDEX IF NOT EXISTS idx_strategies_parent ON strategies(parent_id);
+"""
+
+
+class StrategyPool:
+    """SQLite-backed pool. Connection is opened per-call (cheap on SQLite)
+    so the pool is safe to share across threads — each call gets a fresh
+    connection rather than juggling a single one across the GIL."""
+
+    def __init__(self, db_path: str | Path):
+        self.db_path = Path(db_path)
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        with self._conn() as c:
+            c.executescript(_SCHEMA)
+
+    @contextmanager
+    def _conn(self) -> Iterator[sqlite3.Connection]:
+        conn = sqlite3.connect(self.db_path)
+        conn.row_factory = sqlite3.Row
+        try:
+            yield conn
+            conn.commit()
+        finally:
+            conn.close()
+
+    @staticmethod
+    def _row_to_entry(row: sqlite3.Row) -> StrategyEntry:
+        return StrategyEntry(
+            id=row["id"],
+            name=row["name"],
+            source_code=row["source_code"],
+            parent_id=row["parent_id"],
+            generation=row["generation"],
+            fitness_composite=row["fitness_composite"],
+            fitness_json=row["fitness_json"],
+            backtest_period_start=row["backtest_period_start"],
+            backtest_period_end=row["backtest_period_end"],
+            walkforward_period_start=row["walkforward_period_start"],
+            walkforward_period_end=row["walkforward_period_end"],
+            walkforward_fitness=row["walkforward_fitness"],
+            status=row["status"],
+            created_at=row["created_at"],
+            updated_at=row["updated_at"],
+            notes=row["notes"],
+        )
+
+    def add(self, entry: StrategyEntry) -> str:
+        if entry.status not in STATUSES:
+            raise ValueError(f"Invalid status: {entry.status!r}")
+        with self._conn() as c:
+            c.execute(
+                """
+                INSERT INTO strategies (
+                    id, name, source_code, parent_id, generation,
+                    fitness_composite, fitness_json,
+                    backtest_period_start, backtest_period_end,
+                    walkforward_period_start, walkforward_period_end,
+                    walkforward_fitness, status, created_at, updated_at, notes
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    entry.id, entry.name, entry.source_code,
+                    entry.parent_id, entry.generation,
+                    entry.fitness_composite, entry.fitness_json,
+                    entry.backtest_period_start, entry.backtest_period_end,
+                    entry.walkforward_period_start, entry.walkforward_period_end,
+                    entry.walkforward_fitness, entry.status,
+                    entry.created_at, entry.updated_at, entry.notes,
+                ),
+            )
+        return entry.id
+
+    def get(self, id_: str) -> StrategyEntry | None:
+        with self._conn() as c:
+            row = c.execute(
+                "SELECT * FROM strategies WHERE id = ?", (id_,),
+            ).fetchone()
+        return self._row_to_entry(row) if row else None
+
+    def get_top(self, n: int, status: str = "validated") -> list[StrategyEntry]:
+        """Top-N by walkforward_fitness (descending). Promotion is driven
+        by walk-forward, never by in-sample composite."""
+        if status not in STATUSES:
+            raise ValueError(f"Invalid status: {status!r}")
+        with self._conn() as c:
+            rows = c.execute(
+                """
+                SELECT * FROM strategies
+                WHERE status = ?
+                ORDER BY walkforward_fitness DESC
+                LIMIT ?
+                """,
+                (status, n),
+            ).fetchall()
+        return [self._row_to_entry(r) for r in rows]
+
+    def get_by_status(self, status: str) -> list[StrategyEntry]:
+        if status not in STATUSES:
+            raise ValueError(f"Invalid status: {status!r}")
+        with self._conn() as c:
+            rows = c.execute(
+                "SELECT * FROM strategies WHERE status = ? "
+                "ORDER BY walkforward_fitness DESC",
+                (status,),
+            ).fetchall()
+        return [self._row_to_entry(r) for r in rows]
+
+    def promote(self, id_: str, new_status: str) -> None:
+        if new_status not in STATUSES:
+            raise ValueError(f"Invalid status: {new_status!r}")
+        with self._conn() as c:
+            cursor = c.execute(
+                "UPDATE strategies SET status = ?, updated_at = ? WHERE id = ?",
+                (new_status, _now_iso(), id_),
+            )
+            if cursor.rowcount == 0:
+                raise KeyError(f"No strategy with id {id_!r}")
+
+    def update_fitness(
+        self,
+        id_: str,
+        fitness_dict: dict,
+        walkforward_fitness: float,
+    ) -> None:
+        """Record a fitness evaluation. ``fitness_composite`` is read from
+        ``fitness_dict['composite']`` and the full dict is stored as JSON
+        for later inspection / debugging."""
+        composite = float(fitness_dict.get("composite", 0.0))
+        with self._conn() as c:
+            cursor = c.execute(
+                """
+                UPDATE strategies
+                SET fitness_composite = ?,
+                    fitness_json = ?,
+                    walkforward_fitness = ?,
+                    updated_at = ?
+                WHERE id = ?
+                """,
+                (
+                    composite,
+                    json.dumps(fitness_dict, default=str),
+                    float(walkforward_fitness),
+                    _now_iso(),
+                    id_,
+                ),
+            )
+            if cursor.rowcount == 0:
+                raise KeyError(f"No strategy with id {id_!r}")
+
+    def update_notes(self, id_: str, notes: str) -> None:
+        with self._conn() as c:
+            cursor = c.execute(
+                "UPDATE strategies SET notes = ?, updated_at = ? WHERE id = ?",
+                (notes, _now_iso(), id_),
+            )
+            if cursor.rowcount == 0:
+                raise KeyError(f"No strategy with id {id_!r}")
+
+    def get_lineage(self, id_: str) -> list[StrategyEntry]:
+        """Walk parent_id pointers from this strategy back to the seed.
+
+        Returns ``[entry, parent, grandparent, ..., seed]``. Cycles are
+        defensively guarded against — a malformed pool with a self-parent
+        would otherwise loop forever.
+        """
+        chain: list[StrategyEntry] = []
+        seen: set[str] = set()
+        current = self.get(id_)
+        while current is not None and current.id not in seen:
+            chain.append(current)
+            seen.add(current.id)
+            if current.parent_id is None:
+                break
+            current = self.get(current.parent_id)
+        return chain
+
+    def count(self, status: str | None = None) -> int:
+        with self._conn() as c:
+            if status is None:
+                row = c.execute(
+                    "SELECT COUNT(*) AS n FROM strategies"
+                ).fetchone()
+            else:
+                if status not in STATUSES:
+                    raise ValueError(f"Invalid status: {status!r}")
+                row = c.execute(
+                    "SELECT COUNT(*) AS n FROM strategies WHERE status = ?",
+                    (status,),
+                ).fetchone()
+        return int(row["n"])
+
+    def delete(self, id_: str) -> None:
+        with self._conn() as c:
+            c.execute("DELETE FROM strategies WHERE id = ?", (id_,))
+
+
+def default_pool_path() -> Path:
+    """Conventional location: ``data/evolution_pool.db`` under the repo
+    root (``src/evolution/pool.py`` → parents[2] is the repo root)."""
+    return Path(__file__).resolve().parents[2] / "data" / "evolution_pool.db"

--- a/src/evolution/pool.py
+++ b/src/evolution/pool.py
@@ -1,13 +1,25 @@
 """SQLite-backed strategy gene pool for the Evolution Engine.
 
 Each row is a candidate strategy with its source code, lineage pointer
-to the parent it was mutated from, both in-sample and walk-forward
-fitness, and a status that gates promotion through the pipeline:
+to the parent it was mutated from, three independent fitness slots
+(in-sample, walk-forward, paper-trading), and a status that gates
+promotion through the pipeline:
 
     candidate -> validated -> paper_trading -> live -> retired
 
-``walkforward_fitness`` is the number that actually drives promotion —
-in-sample composite is informational only (overfits trivially).
+Promotion gates:
+  - ``candidate``    -> ``validated``     gated on ``walkforward_fitness``
+    (in-sample composite overfits trivially and is informational only)
+  - ``validated``    -> ``paper_trading`` operator deploys the strategy
+    as a paper bot; SEE doesn't auto-flip this status — running paper
+    is a deliberate human action.
+  - ``paper_trading``-> ``live``          gated on ``paper_trading_fitness``,
+    plus minimum-period / minimum-trade gates enforced by
+    :func:`eligible_for_live` (default: 14 days + 30 trades).
+
+Paper trading data is the closer-to-live signal: no look-ahead bias,
+real market conditions, real fills. ``paper_trading_fitness`` therefore
+carries more weight than ``walkforward_fitness`` for the live gate.
 """
 
 from __future__ import annotations
@@ -48,6 +60,15 @@ class StrategyEntry:
     ``id`` and ``created_at`` / ``updated_at`` default-fill on insert if
     left blank, so callers usually only supply ``name`` + ``source_code``
     (+ optional parent_id / generation) when adding a fresh candidate.
+
+    Three independent fitness fields:
+
+    * ``fitness_composite`` — in-sample backtest composite (informational)
+    * ``walkforward_fitness`` — out-of-sample backtest composite (gate
+      for promotion to ``validated``)
+    * ``paper_trading_fitness`` — composite on accumulated paper-trading
+      results (gate for promotion to ``live``, plus period/trade-count
+      minimums in :func:`eligible_for_live`)
     """
     name: str
     source_code: str
@@ -61,6 +82,10 @@ class StrategyEntry:
     walkforward_period_start: str | None = None
     walkforward_period_end: str | None = None
     walkforward_fitness: float = 0.0
+    paper_trading_fitness: float = 0.0
+    paper_trading_period_start: str | None = None
+    paper_trading_period_end: str | None = None
+    paper_trading_trades: int = 0
     status: str = "candidate"
     created_at: str = field(default_factory=_now_iso)
     updated_at: str = field(default_factory=_now_iso)
@@ -81,6 +106,10 @@ CREATE TABLE IF NOT EXISTS strategies (
     walkforward_period_start TEXT,
     walkforward_period_end TEXT,
     walkforward_fitness REAL NOT NULL DEFAULT 0.0,
+    paper_trading_fitness REAL NOT NULL DEFAULT 0.0,
+    paper_trading_period_start TEXT,
+    paper_trading_period_end TEXT,
+    paper_trading_trades INTEGER NOT NULL DEFAULT 0,
     status TEXT NOT NULL DEFAULT 'candidate',
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL,
@@ -90,7 +119,41 @@ CREATE INDEX IF NOT EXISTS idx_strategies_status ON strategies(status);
 CREATE INDEX IF NOT EXISTS idx_strategies_walkforward
     ON strategies(walkforward_fitness DESC);
 CREATE INDEX IF NOT EXISTS idx_strategies_parent ON strategies(parent_id);
+-- idx_strategies_paper_trading is created in _apply_migrations after
+-- the paper_trading_fitness column is guaranteed to exist. Trying to
+-- create it here would fail on legacy DBs that pre-date the column.
 """
+
+# Additive column migrations for pools created by earlier versions of
+# this module. SQLite's ``ADD COLUMN`` can't be wrapped in
+# ``CREATE TABLE IF NOT EXISTS``, so we check ``PRAGMA table_info`` and
+# add anything missing one-by-one. Each entry: (column_name, DDL fragment).
+_MIGRATIONS: tuple[tuple[str, str], ...] = (
+    ("paper_trading_fitness",
+     "ALTER TABLE strategies ADD COLUMN paper_trading_fitness REAL NOT NULL DEFAULT 0.0"),
+    ("paper_trading_period_start",
+     "ALTER TABLE strategies ADD COLUMN paper_trading_period_start TEXT"),
+    ("paper_trading_period_end",
+     "ALTER TABLE strategies ADD COLUMN paper_trading_period_end TEXT"),
+    ("paper_trading_trades",
+     "ALTER TABLE strategies ADD COLUMN paper_trading_trades INTEGER NOT NULL DEFAULT 0"),
+)
+
+
+def _apply_migrations(conn: sqlite3.Connection) -> None:
+    """Bring an existing pool up to the current schema. No-op when every
+    column already exists (fresh DB or already-migrated)."""
+    existing = {row[1] for row in conn.execute("PRAGMA table_info(strategies)")}
+    for col, ddl in _MIGRATIONS:
+        if col not in existing:
+            conn.execute(ddl)
+    # Indexes are idempotent via CREATE INDEX IF NOT EXISTS — add the
+    # paper-trading one explicitly here for migrated DBs that have the
+    # column but missed the index in _SCHEMA's executescript pass.
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_strategies_paper_trading "
+        "ON strategies(paper_trading_fitness DESC)"
+    )
 
 
 class StrategyPool:
@@ -103,6 +166,9 @@ class StrategyPool:
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
         with self._conn() as c:
             c.executescript(_SCHEMA)
+            # Bring older pools forward. Cheap (single PRAGMA + a few
+            # ALTER TABLEs at most) so we run it on every open.
+            _apply_migrations(c)
 
     @contextmanager
     def _conn(self) -> Iterator[sqlite3.Connection]:
@@ -129,6 +195,10 @@ class StrategyPool:
             walkforward_period_start=row["walkforward_period_start"],
             walkforward_period_end=row["walkforward_period_end"],
             walkforward_fitness=row["walkforward_fitness"],
+            paper_trading_fitness=row["paper_trading_fitness"],
+            paper_trading_period_start=row["paper_trading_period_start"],
+            paper_trading_period_end=row["paper_trading_period_end"],
+            paper_trading_trades=row["paper_trading_trades"],
             status=row["status"],
             created_at=row["created_at"],
             updated_at=row["updated_at"],
@@ -146,8 +216,11 @@ class StrategyPool:
                     fitness_composite, fitness_json,
                     backtest_period_start, backtest_period_end,
                     walkforward_period_start, walkforward_period_end,
-                    walkforward_fitness, status, created_at, updated_at, notes
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    walkforward_fitness,
+                    paper_trading_fitness, paper_trading_period_start,
+                    paper_trading_period_end, paper_trading_trades,
+                    status, created_at, updated_at, notes
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     entry.id, entry.name, entry.source_code,
@@ -155,7 +228,12 @@ class StrategyPool:
                     entry.fitness_composite, entry.fitness_json,
                     entry.backtest_period_start, entry.backtest_period_end,
                     entry.walkforward_period_start, entry.walkforward_period_end,
-                    entry.walkforward_fitness, entry.status,
+                    entry.walkforward_fitness,
+                    entry.paper_trading_fitness,
+                    entry.paper_trading_period_start,
+                    entry.paper_trading_period_end,
+                    entry.paper_trading_trades,
+                    entry.status,
                     entry.created_at, entry.updated_at, entry.notes,
                 ),
             )
@@ -238,6 +316,70 @@ class StrategyPool:
             if cursor.rowcount == 0:
                 raise KeyError(f"No strategy with id {id_!r}")
 
+    def update_paper_trading_fitness(
+        self,
+        id_: str,
+        fitness_dict: dict,
+        paper_trading_fitness: float,
+        period_start: str | None = None,
+        period_end: str | None = None,
+        n_trades: int | None = None,
+    ) -> None:
+        """Record a paper-trading fitness evaluation.
+
+        Unlike :meth:`update_fitness` (which records the backtest pass),
+        this updates the paper-trading slot. ``fitness_json`` is replaced
+        with the full new dict so paper-vs-backtest comparisons are
+        possible later by reading the JSON.
+
+        ``period_start`` / ``period_end`` should be ISO date strings
+        bracketing the paper-trading window the score covers.
+        ``n_trades`` is the number of paper trades that fed into the
+        score — used by :func:`eligible_for_live` to enforce a minimum
+        sample size before live promotion.
+        """
+        composite = float(fitness_dict.get("composite", 0.0))
+        with self._conn() as c:
+            cursor = c.execute(
+                """
+                UPDATE strategies
+                SET paper_trading_fitness = ?,
+                    fitness_json = ?,
+                    paper_trading_period_start = COALESCE(?, paper_trading_period_start),
+                    paper_trading_period_end = COALESCE(?, paper_trading_period_end),
+                    paper_trading_trades = COALESCE(?, paper_trading_trades),
+                    updated_at = ?
+                WHERE id = ?
+                """,
+                (
+                    float(paper_trading_fitness),
+                    json.dumps(fitness_dict, default=str),
+                    period_start,
+                    period_end,
+                    int(n_trades) if n_trades is not None else None,
+                    _now_iso(),
+                    id_,
+                ),
+            )
+            if cursor.rowcount == 0:
+                raise KeyError(f"No strategy with id {id_!r}")
+
+    def get_top_paper_trading(self, n: int) -> list[StrategyEntry]:
+        """Top-N by paper_trading_fitness (descending). The signal that
+        drives live promotion — see :func:`eligible_for_live` for the
+        full gate including minimum period / trade-count."""
+        with self._conn() as c:
+            rows = c.execute(
+                """
+                SELECT * FROM strategies
+                WHERE status = 'paper_trading'
+                ORDER BY paper_trading_fitness DESC
+                LIMIT ?
+                """,
+                (n,),
+            ).fetchall()
+        return [self._row_to_entry(r) for r in rows]
+
     def update_notes(self, id_: str, notes: str) -> None:
         with self._conn() as c:
             cursor = c.execute(
@@ -289,3 +431,79 @@ def default_pool_path() -> Path:
     """Conventional location: ``data/evolution_pool.db`` under the repo
     root (``src/evolution/pool.py`` → parents[2] is the repo root)."""
     return Path(__file__).resolve().parents[2] / "data" / "evolution_pool.db"
+
+
+# ---------------------------------------------------------------------------
+# Promotion gates
+# ---------------------------------------------------------------------------
+
+# Minimum paper-trading exposure before a strategy is considered for live.
+# 14 calendar days catches both day-session-only and night-session bots
+# through at least one full week of each Taiwan futures regime cycle.
+MIN_PAPER_DAYS_FOR_LIVE = 14
+MIN_PAPER_TRADES_FOR_LIVE = 30
+
+# Below this paper-trading fitness, no amount of duration / sample size
+# qualifies a strategy for live. Pickable per-deployment, but the floor
+# reflects the spec: paper-trading composite is the primary live gate.
+DEFAULT_LIVE_FITNESS_THRESHOLD = 0.50
+
+
+def _parse_date(s: str | None) -> datetime | None:
+    if not s:
+        return None
+    for fmt in ("%Y-%m-%d", "%Y-%m-%dT%H:%M:%S", "%Y-%m-%d %H:%M:%S"):
+        try:
+            return datetime.strptime(s, fmt)
+        except ValueError:
+            continue
+    return None
+
+
+def eligible_for_live(
+    entry: StrategyEntry,
+    fitness_threshold: float = DEFAULT_LIVE_FITNESS_THRESHOLD,
+    min_paper_days: int = MIN_PAPER_DAYS_FOR_LIVE,
+    min_paper_trades: int = MIN_PAPER_TRADES_FOR_LIVE,
+    require_positive_walkforward: bool = True,
+) -> tuple[bool, str]:
+    """Decide whether a paper-trading strategy is ready for live promotion.
+
+    Paper-trading composite is the primary signal (closer-to-live: no
+    look-ahead, real market conditions, real fills). Walk-forward acts as
+    a sanity floor — a strategy that LOOKED great in paper but couldn't
+    pass any out-of-sample backtest is probably the wrong kind of lucky.
+
+    Returns ``(eligible, reason)`` so callers can surface a human-readable
+    explanation rather than just a bool. Reason is empty when eligible.
+    """
+    if entry.status != "paper_trading":
+        return False, (
+            f"status is {entry.status!r}, must be 'paper_trading'"
+        )
+    if entry.paper_trading_fitness < fitness_threshold:
+        return False, (
+            f"paper_trading_fitness {entry.paper_trading_fitness:.3f} "
+            f"< threshold {fitness_threshold:.3f}"
+        )
+    if entry.paper_trading_trades < min_paper_trades:
+        return False, (
+            f"paper_trading_trades {entry.paper_trading_trades} "
+            f"< minimum {min_paper_trades}"
+        )
+    start = _parse_date(entry.paper_trading_period_start)
+    end = _parse_date(entry.paper_trading_period_end)
+    if start is None or end is None:
+        return False, "paper_trading period start/end not recorded"
+    span_days = (end - start).days
+    if span_days < min_paper_days:
+        return False, (
+            f"paper-trading window is {span_days} days, "
+            f"minimum {min_paper_days}"
+        )
+    if require_positive_walkforward and entry.walkforward_fitness <= 0:
+        return False, (
+            f"walkforward_fitness {entry.walkforward_fitness:.3f} "
+            f"is not positive — backtest sanity check failed"
+        )
+    return True, ""

--- a/src/live/discord_notify.py
+++ b/src/live/discord_notify.py
@@ -126,6 +126,48 @@ class DiscordNotifier:
             f"淨損益: {net_pnl:+,} | 上限: -{limit:,}"
         )
 
+    def strategy_improved(
+        self,
+        composite: float,
+        previous_best: float,
+        delta: float,
+        n_trades: int,
+        sortino: float,
+        win_rate: float,
+        profit_factor: float,
+        max_drawdown_pct: float,
+        source: str,
+        first_run: bool = False,
+    ) -> None:
+        """Announce that the strategy hit a new best fitness composite.
+
+        Wired by :func:`src.evolution.notify.check_and_notify_after_report`
+        which runs right after the daily report is saved.  ``first_run``
+        gets a slightly different header because there's no prior best
+        to compare against — composite IS the delta.
+        """
+        if first_run:
+            headline = "🌱 **首次評分 First Fitness Score**"
+            delta_str = f"composite **{composite:.3f}**"
+        else:
+            headline = "📈 **策略進步 Strategy Improvement**"
+            delta_str = (
+                f"composite **{composite:.3f}** "
+                f"(前最佳 prev best {previous_best:.3f}, "
+                f"Δ {delta:+.3f})"
+            )
+        self._send(
+            f"{self._header()}\n"
+            f"{headline}\n"
+            f"{delta_str}\n"
+            f"交易數 trades: {n_trades} | "
+            f"勝率 win-rate: {win_rate:.1%} | "
+            f"PF: {profit_factor:.2f}\n"
+            f"Sortino: {sortino:.2f} | "
+            f"最大回撤 max DD: {max_drawdown_pct:.1f}% | "
+            f"來源 source: `{source}`"
+        )
+
     def daily_report(self, report: dict) -> None:
         """Send a daily report summary to Discord."""
         date = report.get("date", "?")

--- a/tests/test_evolution_fitness.py
+++ b/tests/test_evolution_fitness.py
@@ -1,0 +1,284 @@
+"""Tests for src/evolution/fitness.py."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.backtest.broker import Trade, OrderSide
+from src.backtest.metrics import calculate_metrics, PerformanceMetrics
+from src.evolution.fitness import (
+    DEFAULT_WEIGHTS,
+    MIN_TRADES,
+    compute_fitness,
+    consistency_score,
+    regime_scores,
+    sortino_ratio,
+)
+
+
+def make_trade(
+    entry: int,
+    exit_: int,
+    *,
+    pv: int = 200,
+    bar_in: int = 0,
+    bar_out: int = 1,
+    entry_dt: str = "2025-01-01 09:00:00",
+    exit_dt: str = "2025-01-01 10:00:00",
+) -> Trade:
+    pnl = (exit_ - entry) * pv
+    return Trade(
+        tag="L", side=OrderSide.LONG, qty=1,
+        entry_price=entry, exit_price=exit_,
+        entry_bar_index=bar_in, exit_bar_index=bar_out,
+        pnl=pnl, entry_dt=entry_dt, exit_dt=exit_dt,
+    )
+
+
+def _result(trades: list[Trade]) -> dict:
+    """Build the dict shape that compute_fitness accepts."""
+    equity: list[int] = []
+    cum = 0
+    for t in trades:
+        cum += t.pnl
+        equity.append(cum)
+    metrics = calculate_metrics(trades, equity, initial_balance=1_000_000)
+    return {"trades": trades, "equity_curve": equity, "metrics": metrics}
+
+
+def _spread_trades_across_months(n_trades: int, win_rate: float, win_pts: int = 100,
+                                  lose_pts: int = 50) -> list[Trade]:
+    """Build N trades spread across 6 months with the given win rate.
+    Trades alternate win/loss so monthly buckets see both."""
+    out: list[Trade] = []
+    months = ["2025-01", "2025-02", "2025-03", "2025-04", "2025-05", "2025-06"]
+    n_wins = int(round(n_trades * win_rate))
+    for i in range(n_trades):
+        is_win = i < n_wins
+        entry = 20000
+        exit_ = entry + (win_pts if is_win else -lose_pts)
+        m = months[i % len(months)]
+        out.append(make_trade(
+            entry, exit_,
+            entry_dt=f"{m}-15 09:00:00",
+            exit_dt=f"{m}-15 10:00:00",
+        ))
+    return out
+
+
+class TestMinTradeGate:
+    def test_below_min_trades_gates_to_zero(self):
+        # 5 perfect trades — should still be gated.
+        trades = [make_trade(20000, 20100) for _ in range(5)]
+        fit = compute_fitness(_result(trades))
+        assert fit.gated is True
+        assert fit.composite == 0.0
+        # Raw metrics still populated for inspection.
+        assert fit.total_trades == 5
+        assert fit.win_rate == 1.0
+
+    def test_at_min_trades_not_gated(self):
+        trades = _spread_trades_across_months(MIN_TRADES, win_rate=0.6)
+        fit = compute_fitness(_result(trades))
+        assert fit.gated is False
+        assert fit.composite > 0.0
+
+    def test_one_below_min_gated(self):
+        trades = _spread_trades_across_months(MIN_TRADES - 1, win_rate=0.6)
+        fit = compute_fitness(_result(trades))
+        assert fit.gated is True
+        assert fit.composite == 0.0
+
+
+class TestCompositeScoring:
+    def test_composite_in_unit_interval(self):
+        trades = _spread_trades_across_months(40, win_rate=0.6)
+        fit = compute_fitness(_result(trades))
+        assert 0.0 <= fit.composite <= 1.0
+
+    def test_better_strategy_scores_higher(self):
+        good = _spread_trades_across_months(40, win_rate=0.7, win_pts=100, lose_pts=40)
+        bad = _spread_trades_across_months(40, win_rate=0.4, win_pts=80, lose_pts=120)
+        fit_good = compute_fitness(_result(good))
+        fit_bad = compute_fitness(_result(bad))
+        assert fit_good.composite > fit_bad.composite
+
+    def test_high_sharpe_terrible_dd_loses_to_moderate_sharpe_small_dd(self):
+        # Strategy A: 30 medium wins then ONE catastrophic loss.
+        # Tons of profit but the late loss creates a huge drawdown.
+        trades_a: list[Trade] = []
+        months = ["2025-01", "2025-02", "2025-03", "2025-04", "2025-05", "2025-06"]
+        for i in range(30):
+            m = months[i % len(months)]
+            trades_a.append(make_trade(
+                20000, 20120,
+                entry_dt=f"{m}-15 09:00:00", exit_dt=f"{m}-15 10:00:00",
+            ))
+        trades_a.append(make_trade(
+            20000, 14000,  # -6000pts * 200 = -1.2M loss
+            entry_dt="2025-06-20 09:00:00", exit_dt="2025-06-20 10:00:00",
+        ))
+
+        # Strategy B: 40 small steady wins, no big losses.
+        trades_b = _spread_trades_across_months(40, win_rate=0.7, win_pts=60, lose_pts=30)
+
+        fit_a = compute_fitness(_result(trades_a))
+        fit_b = compute_fitness(_result(trades_b))
+
+        # A should be hammered by the drawdown component even though it
+        # has more trades and higher per-trade Sharpe.
+        assert fit_a.max_drawdown_pct > fit_b.max_drawdown_pct
+        assert fit_b.composite > fit_a.composite
+
+    def test_custom_weights(self):
+        trades = _spread_trades_across_months(40, win_rate=0.6)
+        all_drawdown = {k: 0.0 for k in DEFAULT_WEIGHTS}
+        all_drawdown["drawdown"] = 1.0
+        fit_dd_only = compute_fitness(_result(trades), weights=all_drawdown)
+
+        all_winrate = {k: 0.0 for k in DEFAULT_WEIGHTS}
+        all_winrate["win_rate"] = 1.0
+        fit_wr_only = compute_fitness(_result(trades), weights=all_winrate)
+
+        # Both produce values, and they should differ for non-trivial input.
+        assert 0.0 <= fit_dd_only.composite <= 1.0
+        assert 0.0 <= fit_wr_only.composite <= 1.0
+
+
+class TestRegimeScoring:
+    def test_regime_scores_in_unit_interval(self):
+        trades = _spread_trades_across_months(40, win_rate=0.6)
+        fit = compute_fitness(_result(trades))
+        for v in (fit.regime_bull, fit.regime_bear, fit.regime_sideways):
+            assert 0.0 <= v <= 1.0
+
+    def test_only_winning_bull_trades(self):
+        # All long trades that win → all classified as bull regime,
+        # 100% win rate in bull, 0 in bear/sideways.
+        trades: list[Trade] = []
+        months = ["2025-01", "2025-02", "2025-03", "2025-04", "2025-05", "2025-06"]
+        for i in range(35):
+            m = months[i % len(months)]
+            trades.append(make_trade(
+                20000, 20500,  # +2.5% move → bull regime
+                entry_dt=f"{m}-15 09:00:00", exit_dt=f"{m}-15 10:00:00",
+            ))
+        scores = regime_scores(trades)
+        assert scores["bull"] == 1.0
+        assert scores["bear"] == 0.0
+        assert scores["sideways"] == 0.0
+
+    def test_regime_balance_penalizes_one_trick_strategy(self):
+        # Strategy that ONLY trades bull regime (all entries/exits in bull).
+        bull_only = _spread_trades_across_months(40, win_rate=0.6, win_pts=500, lose_pts=400)
+        # Move all trades into 'bull' bucket explicitly: every trade has exit > entry.
+        # Make every loss still bull-classified by widening exit > entry threshold.
+        # (Default _spread mixes wins/losses — losses go bear. We rebuild explicitly.)
+        bull_trades: list[Trade] = []
+        months = ["2025-01", "2025-02", "2025-03", "2025-04", "2025-05", "2025-06"]
+        for i in range(40):
+            entry = 20000
+            # Both wins and losses keep exit > entry by >1% so all are bull.
+            exit_ = entry + (500 if i < 24 else 300)  # 60% wins; all bull
+            m = months[i % len(months)]
+            bull_trades.append(make_trade(
+                entry, exit_,
+                entry_dt=f"{m}-15 09:00:00", exit_dt=f"{m}-15 10:00:00",
+            ))
+
+        # Strategy with similar overall metrics but trades spread across regimes.
+        diverse = _spread_trades_across_months(40, win_rate=0.6, win_pts=500, lose_pts=400)
+
+        fit_bull = compute_fitness(_result(bull_trades))
+        fit_div = compute_fitness(_result(diverse))
+
+        # Bull-only has 0 in bear and sideways → regime_balance ≈ 0 → composite hurt.
+        assert min(fit_bull.regime_bull, fit_bull.regime_bear,
+                   fit_bull.regime_sideways) == 0.0
+
+
+class TestSortino:
+    def test_sortino_no_losses_positive(self):
+        # Only winning trades — Sortino should be a strong positive signal.
+        s = sortino_ratio([100.0, 120.0, 80.0, 150.0])
+        assert s > 0
+
+    def test_sortino_too_few_trades_returns_zero(self):
+        assert sortino_ratio([100.0]) == 0.0
+        assert sortino_ratio([]) == 0.0
+
+    def test_sortino_penalizes_downside(self):
+        # Same mean, but one strategy has a big negative outlier.
+        steady = [50.0, 50.0, 50.0, 50.0, 50.0, 50.0]
+        with_dd = [100.0, 100.0, 100.0, 100.0, 100.0, -250.0]
+        # Same total (300 vs 250) — but with_dd has downside risk and steady has none.
+        s_steady = sortino_ratio(steady)
+        s_dd = sortino_ratio(with_dd)
+        assert s_steady > s_dd
+
+
+class TestConsistency:
+    def test_consistency_zero_with_one_month(self):
+        assert consistency_score({"2025-01": 100.0}) == 0.0
+        assert consistency_score({}) == 0.0
+
+    def test_consistency_one_for_perfectly_steady(self):
+        assert consistency_score({
+            "2025-01": 100.0, "2025-02": 100.0, "2025-03": 100.0,
+        }) == 1.0
+
+    def test_consistency_zero_for_net_losing_months(self):
+        assert consistency_score({
+            "2025-01": -50.0, "2025-02": 30.0, "2025-03": -100.0,
+        }) == 0.0
+
+    def test_steady_scores_higher_than_volatile(self):
+        steady = consistency_score({
+            "2025-01": 100.0, "2025-02": 110.0, "2025-03": 90.0,
+        })
+        volatile = consistency_score({
+            "2025-01": 500.0, "2025-02": -200.0, "2025-03": 100.0,
+        })
+        assert steady > volatile
+
+
+class TestBacktestResultObject:
+    def test_accepts_object_with_attrs(self):
+        """compute_fitness should also work with the engine's
+        BacktestResult object, not just dicts."""
+        class _Stub:
+            pass
+        stub = _Stub()
+        stub.trades = _spread_trades_across_months(40, win_rate=0.6)
+        equity = []
+        cum = 0
+        for t in stub.trades:
+            cum += t.pnl
+            equity.append(cum)
+        stub.equity_curve = equity
+        stub.metrics = calculate_metrics(stub.trades, equity, initial_balance=1_000_000)
+
+        fit = compute_fitness(stub)
+        assert fit.gated is False
+        assert fit.composite > 0.0
+        assert fit.total_trades == 40
+
+    def test_handles_missing_metrics_gracefully(self):
+        fit = compute_fitness({"trades": [], "metrics": None})
+        assert fit.gated is True
+        assert fit.composite == 0.0
+        assert fit.total_trades == 0
+
+
+def test_to_dict_roundtrip():
+    trades = _spread_trades_across_months(40, win_rate=0.6)
+    fit = compute_fitness(_result(trades))
+    d = fit.to_dict()
+    expected_keys = {
+        "composite", "sharpe", "sortino", "max_drawdown_pct",
+        "profit_factor", "win_rate", "consistency",
+        "regime_bull", "regime_bear", "regime_sideways",
+        "total_trades", "gated",
+    }
+    assert set(d.keys()) == expected_keys
+    assert d["composite"] == fit.composite

--- a/tests/test_evolution_fitness.py
+++ b/tests/test_evolution_fitness.py
@@ -10,8 +10,11 @@ from src.evolution.fitness import (
     DEFAULT_WEIGHTS,
     MIN_TRADES,
     compute_fitness,
+    compute_fitness_from_reports,
     consistency_score,
+    label_to_regime,
     regime_scores,
+    regime_scores_from_reports,
     sortino_ratio,
 )
 
@@ -282,3 +285,176 @@ def test_to_dict_roundtrip():
     }
     assert set(d.keys()) == expected_keys
     assert d["composite"] == fit.composite
+
+
+# ---------------------------------------------------------------------------
+# Report-based fitness — consumes the daily-report dict shape produced by
+# src.daily_report.report_generator.generate_report_from_backtest. Uses real
+# ADX/ATR regime labels via label_to_regime() instead of the per-trade
+# naive proxy.
+# ---------------------------------------------------------------------------
+
+
+def _trade_dict(entry: int, exit_: int, *, pnl: int | None = None,
+                entry_dt: str = "2025-01-15 09:00:00",
+                exit_dt: str = "2025-01-15 10:00:00") -> dict:
+    """Shape mirrors _trade_to_dict in src/daily_report/report_generator.py."""
+    return {
+        "tag": "L", "side": "LONG", "qty": 1,
+        "entry_price": entry, "exit_price": exit_,
+        "entry_dt": entry_dt, "exit_dt": exit_dt,
+        "pnl": pnl if pnl is not None else (exit_ - entry) * 200,
+        "entry_bar_index": 0, "exit_bar_index": 1,
+        "exit_tag": "Exit",
+    }
+
+
+def _report(date: str, trades: list[dict], regime_label: str | None = None) -> dict:
+    """Shape mirrors generate_daily_report() output."""
+    block = {"label": regime_label} if regime_label else None
+    return {
+        "date": date,
+        "trades": trades,
+        "summary": {},
+        "market_regime": block,
+    }
+
+
+class TestLabelToRegime:
+    def test_known_labels(self):
+        assert label_to_regime("trending-up") == "bull"
+        assert label_to_regime("transitional-bullish") == "bull"
+        assert label_to_regime("trending-down") == "bear"
+        assert label_to_regime("transitional-bearish") == "bear"
+        assert label_to_regime("range-bound") == "sideways"
+        assert label_to_regime("low-volatility-chop") == "sideways"
+        assert label_to_regime("high-volatility") == "sideways"
+
+    def test_unknown_or_missing(self):
+        assert label_to_regime(None) is None
+        assert label_to_regime("") is None
+        assert label_to_regime("not-a-label") is None
+
+
+class TestRegimeScoresFromReports:
+    def test_buckets_by_label(self):
+        reports = [
+            _report("2025-01-15", [
+                _trade_dict(20000, 20100),  # win
+                _trade_dict(20000, 19900),  # loss
+            ], regime_label="trending-up"),
+            _report("2025-02-15", [
+                _trade_dict(20000, 19800),  # loss
+            ], regime_label="trending-down"),
+            _report("2025-03-15", [
+                _trade_dict(20000, 20100),  # win
+            ], regime_label="range-bound"),
+        ]
+        scores = regime_scores_from_reports(reports)
+        assert scores["bull"] == 0.5      # 1 win / 2 trades
+        assert scores["bear"] == 0.0      # 0 wins / 1 trade
+        assert scores["sideways"] == 1.0  # 1 win / 1 trade
+
+    def test_skips_reports_without_label(self):
+        reports = [
+            _report("2025-01-15", [_trade_dict(20000, 20100)], regime_label=None),
+            _report("2025-02-15", [_trade_dict(20000, 20100)], regime_label="trending-up"),
+        ]
+        scores = regime_scores_from_reports(reports)
+        # Only the labeled report contributes.
+        assert scores["bull"] == 1.0
+        assert scores["bear"] == 0.0
+        assert scores["sideways"] == 0.0
+
+
+class TestComputeFitnessFromReports:
+    def _make_30_winning_reports(self, regime_label: str = "trending-up") -> list[dict]:
+        """30 winning trades across 6 months — clears MIN_TRADES."""
+        reports = []
+        months = ["2025-01", "2025-02", "2025-03", "2025-04", "2025-05", "2025-06"]
+        for i in range(30):
+            m = months[i % len(months)]
+            reports.append(_report(
+                f"{m}-{(i % 28) + 1:02d}",
+                [_trade_dict(20000, 20100,
+                             entry_dt=f"{m}-{(i % 28) + 1:02d} 09:00:00",
+                             exit_dt=f"{m}-{(i % 28) + 1:02d} 10:00:00")],
+                regime_label=regime_label,
+            ))
+        return reports
+
+    def test_basic_scoring_from_reports(self):
+        reports = self._make_30_winning_reports("trending-up")
+        fit = compute_fitness_from_reports(reports)
+        assert fit.gated is False
+        assert fit.total_trades == 30
+        assert fit.composite > 0.0
+        # All trades classified as bull via the real label.
+        assert fit.regime_bull == 1.0
+        assert fit.regime_bear == 0.0
+        assert fit.regime_sideways == 0.0
+
+    def test_gated_when_below_min_trades(self):
+        reports = [
+            _report("2025-01-15",
+                    [_trade_dict(20000, 20100)] * 5,
+                    regime_label="trending-up"),
+        ]
+        fit = compute_fitness_from_reports(reports)
+        assert fit.gated is True
+        assert fit.composite == 0.0
+
+    def test_falls_back_to_naive_when_no_labels(self):
+        """When NO report has a regime label, fall back to the per-trade
+        naive proxy so we still get useful regime scoring."""
+        reports = []
+        months = ["2025-01", "2025-02", "2025-03", "2025-04", "2025-05", "2025-06"]
+        for i in range(30):
+            m = months[i % len(months)]
+            reports.append(_report(
+                f"{m}-{(i % 28) + 1:02d}",
+                [_trade_dict(20000, 20500,  # +2.5% → naive bull
+                             entry_dt=f"{m}-{(i % 28) + 1:02d} 09:00:00",
+                             exit_dt=f"{m}-{(i % 28) + 1:02d} 10:00:00")],
+                regime_label=None,
+            ))
+        fit = compute_fitness_from_reports(reports)
+        # Naive proxy classifies these as bull (exit > entry by >1%).
+        assert fit.regime_bull > 0.0
+
+    def test_consumes_real_pipeline_output(self):
+        """Run the actual generate_report_from_backtest pipeline and
+        ensure compute_fitness_from_reports accepts its output as-is."""
+        from src.daily_report.report_generator import generate_report_from_backtest
+        from src.backtest.broker import Trade, OrderSide
+
+        # Build 30 trades spread across days with the engine's exact
+        # Trade dataclass — same shape generate_report_from_backtest sees.
+        trades = []
+        for i in range(30):
+            day = (i % 28) + 1
+            trades.append(Trade(
+                tag="L", side=OrderSide.LONG, qty=1,
+                entry_price=20000, exit_price=20100,
+                entry_bar_index=i, exit_bar_index=i + 1,
+                pnl=100 * 200,
+                entry_dt=f"2025-01-{day:02d} 09:00:00",
+                exit_dt=f"2025-01-{day:02d} 10:00:00",
+            ))
+        equity_curve = []
+        cum = 0
+        for t in trades:
+            cum += t.pnl
+            equity_curve.append(cum)
+
+        reports = generate_report_from_backtest(
+            trades=trades, equity_curve=equity_curve,
+            # Skip regime classification (insufficient bars). This
+            # exercises the no-label fallback path explicitly.
+            bars_highs=None, bars_lows=None, bars_closes=None,
+            strategy_name="test", point_value=200, save=False,
+        )
+        assert len(reports) > 0
+        fit = compute_fitness_from_reports(reports)
+        assert fit.total_trades == 30
+        assert fit.gated is False

--- a/tests/test_evolution_fitness.py
+++ b/tests/test_evolution_fitness.py
@@ -281,10 +281,12 @@ def test_to_dict_roundtrip():
         "composite", "sharpe", "sortino", "max_drawdown_pct",
         "profit_factor", "win_rate", "consistency",
         "regime_bull", "regime_bear", "regime_sideways",
-        "total_trades", "gated",
+        "total_trades", "gated", "source",
     }
     assert set(d.keys()) == expected_keys
     assert d["composite"] == fit.composite
+    # source defaults to "backtest" for compute_fitness on a raw result.
+    assert d["source"] == "backtest"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_evolution_notify.py
+++ b/tests/test_evolution_notify.py
@@ -1,0 +1,308 @@
+"""Tests for src.evolution.notify — baseline + improvement detection +
+end-to-end glue used by the live daily-report hook.
+
+The fitness math itself is covered by test_evolution_fitness.py; here
+we only care about:
+  * baseline file I/O (load, save, atomic replace, corrupt-file recovery)
+  * detect_improvement decision table
+  * check_and_notify_after_report wiring (send/persist ordering)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone, timedelta
+
+import pytest
+
+from src.evolution.fitness import FitnessResult, SOURCE_BACKTEST, SOURCE_PAPER
+from src.evolution.notify import (
+    Baseline,
+    BASELINE_FILENAME,
+    IMPROVEMENT_DELTA,
+    ImprovementVerdict,
+    baseline_path,
+    check_and_notify_after_report,
+    detect_improvement,
+    load_baseline,
+    save_baseline,
+    score_session_for_notification,
+)
+
+
+_TZ = timezone(timedelta(hours=8))
+
+
+def _fit(composite: float, gated: bool = False, n_trades: int = 50,
+         source: str = SOURCE_PAPER) -> FitnessResult:
+    """Build a FitnessResult with only the fields detect_improvement reads."""
+    return FitnessResult(
+        composite=composite,
+        sharpe=1.0,
+        sortino=1.5,
+        max_drawdown_pct=10.0,
+        profit_factor=1.8,
+        win_rate=0.55,
+        consistency=0.6,
+        regime_bull=0.5,
+        regime_bear=0.5,
+        regime_sideways=0.5,
+        total_trades=n_trades,
+        gated=gated,
+        source=source,
+    )
+
+
+class TestBaselineSerialization:
+    def test_to_dict_roundtrip(self):
+        b = Baseline(best_composite=0.62, best_recorded_at="2026-05-20 13:30:00",
+                     n_updates=3)
+        b2 = Baseline.from_dict(b.to_dict())
+        assert b2 == b
+
+    def test_from_dict_tolerates_missing_keys(self):
+        # Future-proofing: forward-compat with older or partial files
+        b = Baseline.from_dict({})
+        assert b.best_composite == 0.0
+        assert b.best_recorded_at == ""
+        assert b.n_updates == 0
+
+    def test_from_dict_coerces_types(self):
+        b = Baseline.from_dict(
+            {"best_composite": "0.5", "best_recorded_at": 123, "n_updates": "7"}
+        )
+        assert b.best_composite == 0.5
+        assert b.best_recorded_at == "123"
+        assert b.n_updates == 7
+
+
+class TestLoadSaveBaseline:
+    def test_load_returns_none_when_file_missing(self, tmp_path):
+        assert load_baseline(tmp_path) is None
+
+    def test_load_returns_none_on_corrupt_file(self, tmp_path):
+        # detect_improvement falls back to "first run" semantics rather
+        # than raising — the user should still get a notification on
+        # next improvement even if the file got mangled.
+        (tmp_path / BASELINE_FILENAME).write_text("not json", encoding="utf-8")
+        assert load_baseline(tmp_path) is None
+
+    def test_save_creates_directory(self, tmp_path):
+        nested = tmp_path / "deep" / "bot_dir"
+        b = Baseline(best_composite=0.5, best_recorded_at="now", n_updates=1)
+        save_baseline(nested, b)
+        assert (nested / BASELINE_FILENAME).exists()
+
+    def test_save_load_roundtrip(self, tmp_path):
+        original = Baseline(best_composite=0.73,
+                            best_recorded_at="2026-05-20 13:30:00",
+                            n_updates=5)
+        save_baseline(tmp_path, original)
+        loaded = load_baseline(tmp_path)
+        assert loaded == original
+
+    def test_save_is_atomic_no_temp_file_left(self, tmp_path):
+        save_baseline(tmp_path, Baseline(0.5, "x", 1))
+        # The .tmp file used for atomic replace must not remain
+        assert not (tmp_path / (BASELINE_FILENAME + ".tmp")).exists()
+
+
+class TestDetectImprovement:
+    def test_first_run_notifies_and_writes_baseline(self):
+        v = detect_improvement(_fit(0.42), previous=None)
+        assert v.send_notification is True
+        assert v.new_baseline is not None
+        assert v.new_baseline.best_composite == 0.42
+        assert v.new_baseline.n_updates == 1
+        assert "first scored" in v.reason
+
+    def test_gated_never_notifies(self):
+        # Even on first run, a gated fitness (composite forced to 0)
+        # should NOT bootstrap a baseline of 0.0 — that would suppress
+        # all future notifications until composite climbed past 0.05.
+        v = detect_improvement(_fit(0.0, gated=True, n_trades=5),
+                               previous=None)
+        assert v.send_notification is False
+        assert v.new_baseline is None
+        assert "gated" in v.reason
+
+    def test_no_improvement_below_delta(self):
+        prev = Baseline(best_composite=0.5, best_recorded_at="ts", n_updates=1)
+        # 0.50 → 0.54 = +0.04, less than default 0.05 threshold
+        v = detect_improvement(_fit(0.54), previous=prev)
+        assert v.send_notification is False
+        assert v.new_baseline is None
+        assert "no improvement" in v.reason
+
+    def test_no_improvement_when_identical_composite(self):
+        # Idempotency comes from the baseline rewrite (once a score is
+        # notified it becomes the new prev_best → next call with same
+        # score has delta == 0), not from the strict-> operator. The
+        # exact-delta boundary itself is undefined under FP arithmetic
+        # (e.g. 0.55 - 0.5 == 0.05000…044) so we don't pin it.
+        prev = Baseline(best_composite=0.55, best_recorded_at="ts", n_updates=1)
+        v = detect_improvement(_fit(0.55), previous=prev)
+        assert v.send_notification is False
+        assert v.delta == 0.0
+
+    def test_improvement_above_delta_notifies(self):
+        prev = Baseline(best_composite=0.5, best_recorded_at="ts", n_updates=1)
+        v = detect_improvement(_fit(0.60), previous=prev)
+        assert v.send_notification is True
+        assert v.new_baseline is not None
+        assert v.new_baseline.best_composite == 0.60
+        assert v.new_baseline.n_updates == 2
+        assert v.delta == pytest.approx(0.10)
+
+    def test_regression_below_baseline_no_notify(self):
+        # Composite went DOWN — should never notify (and never overwrite
+        # the baseline with a worse score).
+        prev = Baseline(best_composite=0.7, best_recorded_at="ts", n_updates=4)
+        v = detect_improvement(_fit(0.5), previous=prev)
+        assert v.send_notification is False
+        assert v.new_baseline is None
+        assert v.delta < 0
+
+    def test_custom_delta_threshold(self):
+        prev = Baseline(best_composite=0.5, best_recorded_at="ts", n_updates=1)
+        # A stricter threshold means +0.06 isn't enough
+        v_strict = detect_improvement(_fit(0.56), previous=prev, delta=0.10)
+        assert v_strict.send_notification is False
+        # A looser threshold lets +0.02 through
+        v_loose = detect_improvement(_fit(0.52), previous=prev, delta=0.01)
+        assert v_loose.send_notification is True
+
+
+class TestScoreSessionForNotification:
+    def test_paper_mode_tagged_paper(self):
+        trades = [{"pnl": 100, "entry_dt": "2026-05-01 10:00",
+                   "exit_dt": "2026-05-01 11:00"}] * 40
+        fit = score_session_for_notification(
+            trades, equity_curve=None, trading_mode="paper",
+        )
+        assert fit.source == SOURCE_PAPER
+
+    def test_semi_auto_mode_also_tagged_paper(self):
+        # Notification semantics: semi_auto runs real fills with no
+        # look-ahead, so the trades are paper-equivalent for scoring.
+        trades = [{"pnl": 100, "entry_dt": "2026-05-01 10:00",
+                   "exit_dt": "2026-05-01 11:00"}] * 40
+        fit = score_session_for_notification(
+            trades, equity_curve=None, trading_mode="semi_auto",
+        )
+        assert fit.source == SOURCE_PAPER
+
+    def test_auto_mode_also_tagged_paper(self):
+        trades = [{"pnl": 100, "entry_dt": "2026-05-01 10:00",
+                   "exit_dt": "2026-05-01 11:00"}] * 40
+        fit = score_session_for_notification(
+            trades, equity_curve=None, trading_mode="auto",
+        )
+        assert fit.source == SOURCE_PAPER
+
+    def test_backtest_mode_tagged_backtest(self):
+        trades = [{"pnl": 100, "entry_dt": "2026-05-01 10:00",
+                   "exit_dt": "2026-05-01 11:00"}] * 40
+        fit = score_session_for_notification(
+            trades, equity_curve=None, trading_mode="backtest",
+        )
+        assert fit.source == SOURCE_BACKTEST
+
+
+class TestCheckAndNotifyAfterReport:
+    """End-to-end glue test the GUI hook depends on."""
+
+    def _trades(self, n: int):
+        # >=30 to clear the MIN_TRADES gate; mix winners/losers so
+        # the fitness composite is non-trivial.
+        return [
+            {"pnl": 100 if i % 2 == 0 else -50,
+             "entry_dt": f"2026-05-{(i % 28) + 1:02d} 10:00",
+             "exit_dt": f"2026-05-{(i % 28) + 1:02d} 11:00",
+             "entry_price": 1000, "exit_price": 1100 if i % 2 == 0 else 950,
+             "entry_bar_index": i * 2, "exit_bar_index": i * 2 + 1}
+            for i in range(n)
+        ]
+
+    def test_first_run_writes_baseline_and_invokes_callback(self, tmp_path):
+        captured: list[ImprovementVerdict] = []
+        verdict = check_and_notify_after_report(
+            bot_dir=tmp_path,
+            trades=self._trades(50),
+            equity_curve=None,
+            trading_mode="semi_auto",
+            send_notification=captured.append,
+        )
+        assert verdict.send_notification is True
+        assert len(captured) == 1
+        assert captured[0] is verdict
+        # Baseline file MUST exist after the send
+        assert (tmp_path / BASELINE_FILENAME).exists()
+
+    def test_callback_exception_does_not_crash(self, tmp_path):
+        def _bad(_v):
+            raise RuntimeError("discord down")
+
+        # No assertion error — the exception must be swallowed
+        verdict = check_and_notify_after_report(
+            bot_dir=tmp_path,
+            trades=self._trades(50),
+            equity_curve=None,
+            trading_mode="semi_auto",
+            send_notification=_bad,
+        )
+        assert verdict.send_notification is True
+        # Baseline still got persisted (we save BEFORE the send call)
+        assert (tmp_path / BASELINE_FILENAME).exists()
+
+    def test_no_trades_returns_gated_no_baseline(self, tmp_path):
+        captured: list[ImprovementVerdict] = []
+        verdict = check_and_notify_after_report(
+            bot_dir=tmp_path,
+            trades=[],
+            equity_curve=[],
+            trading_mode="semi_auto",
+            send_notification=captured.append,
+        )
+        # Empty trades → gated; no notification, no baseline.
+        assert verdict.send_notification is False
+        assert captured == []
+        assert not (tmp_path / BASELINE_FILENAME).exists()
+
+    def test_second_call_no_improvement_keeps_old_baseline(self, tmp_path):
+        # First call writes baseline at composite ~X
+        v1 = check_and_notify_after_report(
+            bot_dir=tmp_path,
+            trades=self._trades(50),
+            equity_curve=None,
+            trading_mode="semi_auto",
+        )
+        assert v1.send_notification is True
+        first_baseline = load_baseline(tmp_path)
+        assert first_baseline is not None
+
+        # Second call with the SAME trades → same composite → no
+        # improvement → baseline file must not be touched.
+        v2 = check_and_notify_after_report(
+            bot_dir=tmp_path,
+            trades=self._trades(50),
+            equity_curve=None,
+            trading_mode="semi_auto",
+        )
+        assert v2.send_notification is False
+        second_baseline = load_baseline(tmp_path)
+        assert second_baseline == first_baseline
+
+    def test_no_send_when_callback_is_none(self, tmp_path):
+        # Callback is optional — code path must work for "dry-run"
+        # callers (e.g. tests or a GUI mode with Discord disabled).
+        verdict = check_and_notify_after_report(
+            bot_dir=tmp_path,
+            trades=self._trades(50),
+            equity_curve=None,
+            trading_mode="semi_auto",
+            send_notification=None,
+        )
+        assert verdict.send_notification is True
+        assert (tmp_path / BASELINE_FILENAME).exists()

--- a/tests/test_evolution_paper_trading.py
+++ b/tests/test_evolution_paper_trading.py
@@ -1,0 +1,320 @@
+"""End-to-end tests for the paper-trading scoring flow.
+
+Covers the integration between LiveRunner's session.json shape, the
+input-agnostic fitness function, and the pool's paper_trading_* columns.
+The key invariant: paper trades produce the IDENTICAL data shape as
+backtest trades (both flow through SimulatedBroker), so the fitness math
+shouldn't care. Only the ``source`` tag and the destination columns differ.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.backtest.broker import OrderSide, SimulatedBroker, Trade
+from src.evolution.evaluator import (
+    score_paper_session,
+    score_paper_trading_results,
+)
+from src.evolution.fitness import (
+    SOURCE_BACKTEST,
+    SOURCE_PAPER,
+    compute_fitness_from_trades,
+)
+from src.evolution.pool import (
+    StrategyEntry,
+    StrategyPool,
+    eligible_for_live,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_trades(n: int, win_rate: float = 0.6, pv: int = 200,
+                 base_date: str = "2025") -> list[Trade]:
+    """Build n Trade dataclass instances spread across 6 months.
+
+    Same fixture pattern as test_evolution_fitness so a strategy scoring
+    well in backtest should produce the same composite when the trades
+    are reframed as paper-trading data — which is exactly the property
+    we want to test."""
+    out: list[Trade] = []
+    months = [f"{base_date}-0{i+1}" for i in range(6)]
+    n_wins = int(round(n * win_rate))
+    for i in range(n):
+        is_win = i < n_wins
+        entry, exit_ = 20000, 20000 + (100 if is_win else -50)
+        m = months[i % len(months)]
+        out.append(Trade(
+            tag="L", side=OrderSide.LONG, qty=1,
+            entry_price=entry, exit_price=exit_,
+            entry_bar_index=i, exit_bar_index=i + 1,
+            pnl=(exit_ - entry) * pv,
+            entry_dt=f"{m}-15 09:00:00",
+            exit_dt=f"{m}-15 10:00:00",
+        ))
+    return out
+
+
+def _make_session_dict(trades: list[Trade], started_at: str = "2026-01-01T08:45:00",
+                       saved_at: str = "2026-01-21T13:45:00",
+                       trading_mode: str = "paper") -> dict:
+    """Mirror the session.json shape written by LiveRunner._auto_save_session."""
+    # Build a real SimulatedBroker, push trades through to_dict for a
+    # faithful serialization — guards against future drift in either
+    # the live save format or the broker's serialization.
+    broker = SimulatedBroker(point_value=200)
+    broker.trades = list(trades)
+    broker._cumulative_pnl = sum(t.pnl for t in trades)
+    broker.equity_curve = []
+    cum = 0
+    for t in trades:
+        cum += t.pnl
+        broker.equity_curve.append(cum)
+
+    return {
+        "strategy": "test-strategy",
+        "symbol": "TXF1",
+        "bot_name": "test-bot",
+        "point_value": 200,
+        "trading_mode": trading_mode,
+        "started_at": started_at,
+        "saved_at": saved_at,
+        "bar_index": len(trades) + 100,
+        "broker": broker.to_dict(),
+    }
+
+
+@pytest.fixture
+def pool(tmp_path):
+    return StrategyPool(tmp_path / "pool.db")
+
+
+@pytest.fixture
+def candidate_id(pool):
+    entry = StrategyEntry(
+        name="candidate", source_code="# candidate",
+        walkforward_fitness=0.40, status="paper_trading",
+    )
+    pool.add(entry)
+    return entry.id
+
+
+# ---------------------------------------------------------------------------
+# Input-agnostic fitness: backtest vs paper produces identical math
+# ---------------------------------------------------------------------------
+
+
+class TestSourceAgnosticFitness:
+    def test_backtest_and_paper_match_when_trades_identical(self):
+        """The whole point of the source field: same trades → same
+        composite, with only the source tag differing."""
+        trades = _make_trades(40, win_rate=0.6)
+        bt = compute_fitness_from_trades(trades, source=SOURCE_BACKTEST)
+        paper = compute_fitness_from_trades(trades, source=SOURCE_PAPER)
+        assert bt.composite == paper.composite
+        assert bt.sharpe == paper.sharpe
+        assert bt.total_trades == paper.total_trades
+        assert bt.source == "backtest"
+        assert paper.source == "paper"
+
+    def test_rejects_invalid_source(self):
+        with pytest.raises(ValueError):
+            compute_fitness_from_trades([], source="garbage")
+
+    def test_accepts_trade_dicts_and_dataclasses(self):
+        """Paper sessions can hand us either shape — Trade instances
+        from a live SimulatedBroker, or dicts after JSON round-trip."""
+        trades = _make_trades(40)
+        as_dicts = [
+            {
+                "pnl": t.pnl, "entry_price": t.entry_price,
+                "exit_price": t.exit_price, "entry_dt": t.entry_dt,
+                "exit_dt": t.exit_dt, "entry_bar_index": t.entry_bar_index,
+                "exit_bar_index": t.exit_bar_index,
+            }
+            for t in trades
+        ]
+        fit_a = compute_fitness_from_trades(trades, source=SOURCE_PAPER)
+        fit_b = compute_fitness_from_trades(as_dicts, source=SOURCE_PAPER)
+        assert fit_a.total_trades == fit_b.total_trades
+        assert fit_a.composite == pytest.approx(fit_b.composite)
+
+    def test_rebuilds_equity_curve_when_omitted(self):
+        trades = _make_trades(30)
+        fit = compute_fitness_from_trades(trades, source=SOURCE_PAPER)
+        # Should not crash and total_trades should still be 30.
+        assert fit.total_trades == 30
+
+    def test_gating_still_applies(self):
+        # Below MIN_TRADES (30), paper fitness gates to 0 too.
+        trades = _make_trades(10)
+        fit = compute_fitness_from_trades(trades, source=SOURCE_PAPER)
+        assert fit.gated is True
+        assert fit.composite == 0.0
+
+
+# ---------------------------------------------------------------------------
+# score_paper_trading_results: updates the pool's paper_trading columns
+# ---------------------------------------------------------------------------
+
+
+class TestScorePaperTradingResults:
+    def test_updates_pool_columns(self, pool, candidate_id):
+        trades = _make_trades(40, win_rate=0.7)
+        fit = score_paper_trading_results(
+            pool, candidate_id, trades,
+            period_start="2026-01-01", period_end="2026-01-20",
+        )
+        assert fit.source == "paper"
+        loaded = pool.get(candidate_id)
+        assert loaded.paper_trading_fitness == pytest.approx(fit.composite)
+        assert loaded.paper_trading_period_start == "2026-01-01"
+        assert loaded.paper_trading_period_end == "2026-01-20"
+        assert loaded.paper_trading_trades == 40
+
+    def test_does_not_touch_walkforward(self, pool, candidate_id):
+        """Backtest columns are sacred — paper scoring must never
+        accidentally overwrite walkforward_fitness."""
+        before = pool.get(candidate_id).walkforward_fitness
+        score_paper_trading_results(
+            pool, candidate_id, _make_trades(40),
+            period_start="2026-01-01", period_end="2026-01-20",
+        )
+        after = pool.get(candidate_id).walkforward_fitness
+        assert before == after
+
+    def test_missing_id_raises(self, pool):
+        with pytest.raises(KeyError):
+            score_paper_trading_results(
+                pool, "no-such-id", _make_trades(40),
+            )
+
+
+# ---------------------------------------------------------------------------
+# score_paper_session: load session.json -> score -> update pool
+# ---------------------------------------------------------------------------
+
+
+class TestScorePaperSession:
+    def _write_session(self, dir_: Path, trades: list[Trade], **kwargs) -> str:
+        session = _make_session_dict(trades, **kwargs)
+        path = dir_ / "session.json"
+        path.write_text(json.dumps(session, default=str), encoding="utf-8")
+        return str(path)
+
+    def test_end_to_end_paper_session(self, pool, candidate_id, tmp_path):
+        path = self._write_session(
+            tmp_path, _make_trades(40, win_rate=0.6),
+            started_at="2026-01-01T08:45:00",
+            saved_at="2026-01-20T13:45:00",
+        )
+        fit = score_paper_session(pool, candidate_id, path)
+        assert fit is not None
+        assert fit.source == "paper"
+        assert fit.total_trades == 40
+
+        loaded = pool.get(candidate_id)
+        assert loaded.paper_trading_fitness == pytest.approx(fit.composite)
+        # Period derived from started_at / saved_at, date portion only.
+        assert loaded.paper_trading_period_start == "2026-01-01"
+        assert loaded.paper_trading_period_end == "2026-01-20"
+
+    def test_missing_session_returns_none(self, pool, candidate_id, tmp_path):
+        """Sessions can be rotated/deleted; that shouldn't be a hard
+        error from the SEE side."""
+        path = tmp_path / "does-not-exist.json"
+        result = score_paper_session(pool, candidate_id, str(path))
+        assert result is None
+        # Pool was NOT touched.
+        loaded = pool.get(candidate_id)
+        assert loaded.paper_trading_fitness == 0.0
+
+    def test_refuses_non_paper_mode(self, pool, candidate_id, tmp_path):
+        """semi_auto / auto sessions carry real-money trades — refuse
+        to score them as paper. They need a separate, deliberate path."""
+        path = self._write_session(
+            tmp_path, _make_trades(40), trading_mode="auto",
+        )
+        with pytest.raises(ValueError, match="trading_mode"):
+            score_paper_session(pool, candidate_id, path)
+
+    def test_accepts_legacy_session_without_trading_mode(
+            self, pool, candidate_id, tmp_path):
+        """Sessions saved before the trading_mode field existed are
+        treated as paper by default."""
+        session = _make_session_dict(_make_trades(40))
+        del session["trading_mode"]
+        path = tmp_path / "session.json"
+        path.write_text(json.dumps(session, default=str), encoding="utf-8")
+        result = score_paper_session(pool, candidate_id, str(path))
+        assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# Full pipeline: candidate -> validated -> paper_trading -> eligible -> live
+# ---------------------------------------------------------------------------
+
+
+class TestPromotionPipeline:
+    def test_full_promotion_flow(self, pool, tmp_path):
+        # 1. Add as candidate.
+        entry = StrategyEntry(
+            name="pipeline-strategy", source_code="# code",
+            status="candidate",
+        )
+        pool.add(entry)
+        assert pool.get(entry.id).status == "candidate"
+
+        # 2. Record backtest fitness, promote to validated.
+        pool.update_fitness(
+            entry.id, {"composite": 0.55, "sharpe": 1.4}, walkforward_fitness=0.45,
+        )
+        pool.promote(entry.id, "validated")
+        loaded = pool.get(entry.id)
+        assert loaded.status == "validated"
+        assert loaded.walkforward_fitness == pytest.approx(0.45)
+
+        # 3. Operator deploys as paper bot — flips status manually.
+        pool.promote(entry.id, "paper_trading")
+
+        # 4. Score accumulated paper trades.
+        score_paper_trading_results(
+            pool, entry.id,
+            _make_trades(40, win_rate=0.7, base_date="2026"),
+            period_start="2026-01-01", period_end="2026-01-22",
+        )
+
+        # 5. Check eligibility for live.
+        loaded = pool.get(entry.id)
+        ok, reason = eligible_for_live(loaded, fitness_threshold=0.20)
+        assert ok is True, f"should be eligible, got: {reason}"
+
+        # 6. Final promotion.
+        pool.promote(entry.id, "live")
+        assert pool.get(entry.id).status == "live"
+
+    def test_paper_score_below_threshold_blocks_live(self, pool):
+        # 40 trades but mostly losers — paper fitness should be near 0
+        # and eligibility should fail on the threshold check.
+        entry = StrategyEntry(
+            name="bad", source_code="# code",
+            walkforward_fitness=0.45, status="paper_trading",
+        )
+        pool.add(entry)
+        # All-losing trades → paper fitness will be very low.
+        losing = _make_trades(40, win_rate=0.0, base_date="2026")
+        score_paper_trading_results(
+            pool, entry.id, losing,
+            period_start="2026-01-01", period_end="2026-01-22",
+        )
+        loaded = pool.get(entry.id)
+        ok, reason = eligible_for_live(loaded)
+        assert ok is False
+        assert "fitness" in reason

--- a/tests/test_evolution_pool.py
+++ b/tests/test_evolution_pool.py
@@ -1,0 +1,214 @@
+"""Tests for src/evolution/pool.py."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from src.evolution.pool import StrategyEntry, StrategyPool
+
+
+@pytest.fixture
+def pool(tmp_path):
+    return StrategyPool(tmp_path / "evolution_pool.db")
+
+
+def make_entry(name: str = "seed", **overrides) -> StrategyEntry:
+    base = dict(name=name, source_code=f"# {name}\nclass {name.title()}: ...")
+    base.update(overrides)
+    return StrategyEntry(**base)
+
+
+class TestAddAndGet:
+    def test_add_returns_id(self, pool):
+        entry = make_entry()
+        sid = pool.add(entry)
+        assert sid == entry.id
+        assert pool.count() == 1
+
+    def test_get_roundtrip(self, pool):
+        entry = make_entry(
+            generation=2,
+            fitness_composite=0.42,
+            walkforward_fitness=0.31,
+            backtest_period_start="2025-01-01",
+            backtest_period_end="2025-04-01",
+            walkforward_period_start="2025-04-01",
+            walkforward_period_end="2025-07-01",
+            notes="seed test",
+        )
+        pool.add(entry)
+        loaded = pool.get(entry.id)
+        assert loaded is not None
+        assert loaded.name == entry.name
+        assert loaded.source_code == entry.source_code
+        assert loaded.generation == 2
+        assert loaded.fitness_composite == pytest.approx(0.42)
+        assert loaded.walkforward_fitness == pytest.approx(0.31)
+        assert loaded.backtest_period_start == "2025-01-01"
+        assert loaded.notes == "seed test"
+
+    def test_get_missing_returns_none(self, pool):
+        assert pool.get("does-not-exist") is None
+
+    def test_invalid_status_rejected_on_add(self, pool):
+        entry = make_entry(status="bogus")
+        with pytest.raises(ValueError):
+            pool.add(entry)
+
+
+class TestGetTop:
+    def test_get_top_orders_by_walkforward_fitness(self, pool):
+        e1 = make_entry(name="a", walkforward_fitness=0.10, status="validated")
+        e2 = make_entry(name="b", walkforward_fitness=0.50, status="validated")
+        e3 = make_entry(name="c", walkforward_fitness=0.30, status="validated")
+        for e in (e1, e2, e3):
+            pool.add(e)
+
+        top = pool.get_top(2, status="validated")
+        assert [e.name for e in top] == ["b", "c"]
+
+    def test_get_top_filters_by_status(self, pool):
+        # Same fitness, different statuses — only validated should show up.
+        for status in ("candidate", "validated", "validated", "retired"):
+            pool.add(make_entry(name=status, walkforward_fitness=0.5, status=status))
+        top = pool.get_top(10, status="validated")
+        assert len(top) == 2
+        assert all(e.status == "validated" for e in top)
+
+    def test_get_top_n_caps_results(self, pool):
+        for i in range(5):
+            pool.add(make_entry(name=f"s{i}", walkforward_fitness=float(i),
+                                status="validated"))
+        top = pool.get_top(3, status="validated")
+        assert len(top) == 3
+        assert top[0].walkforward_fitness == 4.0
+        assert top[1].walkforward_fitness == 3.0
+        assert top[2].walkforward_fitness == 2.0
+
+
+class TestPromote:
+    def test_promote_changes_status(self, pool):
+        entry = make_entry()
+        pool.add(entry)
+        pool.promote(entry.id, "validated")
+        loaded = pool.get(entry.id)
+        assert loaded.status == "validated"
+
+    def test_promote_invalid_status(self, pool):
+        entry = make_entry()
+        pool.add(entry)
+        with pytest.raises(ValueError):
+            pool.promote(entry.id, "not-a-status")
+
+    def test_promote_missing_raises(self, pool):
+        with pytest.raises(KeyError):
+            pool.promote("missing-id", "validated")
+
+    def test_promote_updates_updated_at(self, pool):
+        entry = make_entry()
+        pool.add(entry)
+        before = pool.get(entry.id).updated_at
+        # Force at least 1s of clock movement is unreliable, but we can
+        # at least verify the new value is a valid ISO timestamp.
+        pool.promote(entry.id, "validated")
+        after = pool.get(entry.id).updated_at
+        assert after >= before
+
+
+class TestUpdateFitness:
+    def test_update_fitness_records_composite_and_walkforward(self, pool):
+        entry = make_entry()
+        pool.add(entry)
+        fitness_dict = {
+            "composite": 0.65, "sharpe": 1.5, "sortino": 1.7,
+            "max_drawdown_pct": 8.0, "win_rate": 0.6,
+        }
+        pool.update_fitness(entry.id, fitness_dict, walkforward_fitness=0.50)
+        loaded = pool.get(entry.id)
+        assert loaded.fitness_composite == pytest.approx(0.65)
+        assert loaded.walkforward_fitness == pytest.approx(0.50)
+        decoded = json.loads(loaded.fitness_json)
+        assert decoded["sharpe"] == 1.5
+        assert decoded["win_rate"] == 0.6
+
+    def test_update_fitness_missing_raises(self, pool):
+        with pytest.raises(KeyError):
+            pool.update_fitness("missing", {"composite": 0.1}, 0.1)
+
+
+class TestLineage:
+    def test_lineage_returns_chain_from_self_to_seed(self, pool):
+        seed = make_entry(name="seed", generation=0)
+        gen1 = make_entry(name="gen1", parent_id=seed.id, generation=1)
+        gen2 = make_entry(name="gen2", parent_id=gen1.id, generation=2)
+        gen3 = make_entry(name="gen3", parent_id=gen2.id, generation=3)
+        for e in (seed, gen1, gen2, gen3):
+            pool.add(e)
+
+        lineage = pool.get_lineage(gen3.id)
+        assert [e.name for e in lineage] == ["gen3", "gen2", "gen1", "seed"]
+
+    def test_lineage_seed_only_returns_self(self, pool):
+        seed = make_entry(name="seed")
+        pool.add(seed)
+        chain = pool.get_lineage(seed.id)
+        assert [e.name for e in chain] == ["seed"]
+
+    def test_lineage_missing_returns_empty(self, pool):
+        assert pool.get_lineage("missing") == []
+
+    def test_lineage_handles_self_parent_cycle(self, pool):
+        # Pathological: a strategy that's its own parent. Shouldn't loop.
+        bad = make_entry(name="ouroboros")
+        bad.parent_id = bad.id
+        pool.add(bad)
+        chain = pool.get_lineage(bad.id)
+        assert len(chain) == 1
+
+
+class TestStatus:
+    def test_get_by_status(self, pool):
+        for s in ("candidate", "candidate", "validated", "retired"):
+            pool.add(make_entry(name=s, status=s))
+        cands = pool.get_by_status("candidate")
+        assert len(cands) == 2
+        assert all(e.status == "candidate" for e in cands)
+
+    def test_count_by_status(self, pool):
+        for _ in range(3):
+            pool.add(make_entry(status="candidate"))
+        for _ in range(2):
+            pool.add(make_entry(status="validated"))
+        assert pool.count() == 5
+        assert pool.count("candidate") == 3
+        assert pool.count("validated") == 2
+        assert pool.count("retired") == 0
+
+
+class TestNotes:
+    def test_update_notes(self, pool):
+        entry = make_entry()
+        pool.add(entry)
+        pool.update_notes(entry.id, "ai-flagged: looks like overfit on 2025-Q1")
+        loaded = pool.get(entry.id)
+        assert "overfit" in loaded.notes
+
+
+class TestPersistence:
+    def test_pool_survives_reopen(self, tmp_path):
+        path = tmp_path / "evolution_pool.db"
+        pool1 = StrategyPool(path)
+        entry = make_entry(walkforward_fitness=0.42, status="validated")
+        pool1.add(entry)
+
+        pool2 = StrategyPool(path)
+        loaded = pool2.get(entry.id)
+        assert loaded is not None
+        assert loaded.walkforward_fitness == pytest.approx(0.42)
+
+    def test_creates_parent_directory(self, tmp_path):
+        nested = tmp_path / "newdir" / "evolution_pool.db"
+        StrategyPool(nested)
+        assert nested.parent.exists()

--- a/tests/test_evolution_pool.py
+++ b/tests/test_evolution_pool.py
@@ -3,10 +3,18 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 
 import pytest
 
-from src.evolution.pool import StrategyEntry, StrategyPool
+from src.evolution.pool import (
+    DEFAULT_LIVE_FITNESS_THRESHOLD,
+    MIN_PAPER_DAYS_FOR_LIVE,
+    MIN_PAPER_TRADES_FOR_LIVE,
+    StrategyEntry,
+    StrategyPool,
+    eligible_for_live,
+)
 
 
 @pytest.fixture
@@ -212,3 +220,266 @@ class TestPersistence:
         nested = tmp_path / "newdir" / "evolution_pool.db"
         StrategyPool(nested)
         assert nested.parent.exists()
+
+
+class TestPaperTradingFitness:
+    def test_default_paper_fields(self, pool):
+        entry = make_entry()
+        pool.add(entry)
+        loaded = pool.get(entry.id)
+        assert loaded.paper_trading_fitness == 0.0
+        assert loaded.paper_trading_trades == 0
+        assert loaded.paper_trading_period_start is None
+        assert loaded.paper_trading_period_end is None
+
+    def test_update_paper_trading_fitness(self, pool):
+        entry = make_entry()
+        pool.add(entry)
+        fitness_dict = {
+            "composite": 0.62, "sharpe": 1.4, "source": "paper",
+        }
+        pool.update_paper_trading_fitness(
+            entry.id,
+            fitness_dict,
+            paper_trading_fitness=0.62,
+            period_start="2026-01-01",
+            period_end="2026-01-20",
+            n_trades=45,
+        )
+        loaded = pool.get(entry.id)
+        assert loaded.paper_trading_fitness == pytest.approx(0.62)
+        assert loaded.paper_trading_period_start == "2026-01-01"
+        assert loaded.paper_trading_period_end == "2026-01-20"
+        assert loaded.paper_trading_trades == 45
+        # fitness_json was overwritten with the paper score blob
+        decoded = json.loads(loaded.fitness_json)
+        assert decoded["source"] == "paper"
+
+    def test_update_paper_preserves_walkforward_columns(self, pool):
+        """Updating paper-trading fitness must NOT clobber backtest
+        columns — backtest and paper-trading scores live independently."""
+        entry = make_entry(
+            walkforward_fitness=0.55,
+            fitness_composite=0.40,
+            backtest_period_start="2025-10-01",
+            backtest_period_end="2026-01-01",
+        )
+        pool.add(entry)
+        pool.update_paper_trading_fitness(
+            entry.id, {"composite": 0.30}, paper_trading_fitness=0.30,
+            period_start="2026-01-01", period_end="2026-01-20", n_trades=40,
+        )
+        loaded = pool.get(entry.id)
+        # Paper update landed.
+        assert loaded.paper_trading_fitness == pytest.approx(0.30)
+        # Backtest fields untouched.
+        assert loaded.walkforward_fitness == pytest.approx(0.55)
+        assert loaded.fitness_composite == pytest.approx(0.40)
+        assert loaded.backtest_period_start == "2025-10-01"
+
+    def test_update_paper_missing_raises(self, pool):
+        with pytest.raises(KeyError):
+            pool.update_paper_trading_fitness(
+                "missing", {"composite": 0.1}, 0.1,
+            )
+
+    def test_partial_update_preserves_unspecified(self, pool):
+        """Subsequent updates with only some fields should keep the rest."""
+        entry = make_entry()
+        pool.add(entry)
+        pool.update_paper_trading_fitness(
+            entry.id, {"composite": 0.5}, paper_trading_fitness=0.5,
+            period_start="2026-01-01", period_end="2026-01-20", n_trades=35,
+        )
+        # Second update without period/trades — should keep the first values.
+        pool.update_paper_trading_fitness(
+            entry.id, {"composite": 0.55}, paper_trading_fitness=0.55,
+        )
+        loaded = pool.get(entry.id)
+        assert loaded.paper_trading_fitness == pytest.approx(0.55)
+        assert loaded.paper_trading_period_start == "2026-01-01"
+        assert loaded.paper_trading_period_end == "2026-01-20"
+        assert loaded.paper_trading_trades == 35
+
+    def test_get_top_paper_trading(self, pool):
+        for i, fit in enumerate([0.10, 0.50, 0.30, 0.70]):
+            entry = make_entry(
+                name=f"p{i}",
+                paper_trading_fitness=fit,
+                status="paper_trading",
+            )
+            pool.add(entry)
+        top = pool.get_top_paper_trading(2)
+        assert [e.paper_trading_fitness for e in top] == [0.70, 0.50]
+
+    def test_get_top_paper_trading_filters_by_status(self, pool):
+        # High paper_trading_fitness but wrong status — should be skipped.
+        pool.add(make_entry(
+            name="wrong-status", paper_trading_fitness=0.99, status="validated",
+        ))
+        pool.add(make_entry(
+            name="right-status", paper_trading_fitness=0.50, status="paper_trading",
+        ))
+        top = pool.get_top_paper_trading(10)
+        assert len(top) == 1
+        assert top[0].name == "right-status"
+
+
+class TestEligibleForLive:
+    def _ready_entry(self) -> StrategyEntry:
+        return StrategyEntry(
+            name="ready",
+            source_code="...",
+            walkforward_fitness=0.40,
+            paper_trading_fitness=0.65,
+            paper_trading_trades=MIN_PAPER_TRADES_FOR_LIVE + 5,
+            paper_trading_period_start="2026-01-01",
+            paper_trading_period_end="2026-01-25",  # 24 days > 14
+            status="paper_trading",
+        )
+
+    def test_happy_path_eligible(self):
+        ok, reason = eligible_for_live(self._ready_entry())
+        assert ok is True
+        assert reason == ""
+
+    def test_wrong_status(self):
+        entry = self._ready_entry()
+        entry.status = "validated"
+        ok, reason = eligible_for_live(entry)
+        assert ok is False
+        assert "status" in reason
+
+    def test_fitness_below_threshold(self):
+        entry = self._ready_entry()
+        entry.paper_trading_fitness = 0.30
+        ok, reason = eligible_for_live(
+            entry, fitness_threshold=DEFAULT_LIVE_FITNESS_THRESHOLD,
+        )
+        assert ok is False
+        assert "fitness" in reason
+
+    def test_trade_count_below_minimum(self):
+        entry = self._ready_entry()
+        entry.paper_trading_trades = 10
+        ok, reason = eligible_for_live(entry)
+        assert ok is False
+        assert "trades" in reason
+
+    def test_window_too_short(self):
+        entry = self._ready_entry()
+        entry.paper_trading_period_end = "2026-01-05"  # 4 days
+        ok, reason = eligible_for_live(entry)
+        assert ok is False
+        assert "days" in reason or "window" in reason
+
+    def test_missing_period_data(self):
+        entry = self._ready_entry()
+        entry.paper_trading_period_start = None
+        ok, reason = eligible_for_live(entry)
+        assert ok is False
+        assert "period" in reason
+
+    def test_negative_walkforward_blocks_unless_overridden(self):
+        entry = self._ready_entry()
+        entry.walkforward_fitness = -0.10
+        # Default: blocked.
+        ok, _ = eligible_for_live(entry)
+        assert ok is False
+        # Caller can override (e.g. for emergency promotion).
+        ok2, _ = eligible_for_live(entry, require_positive_walkforward=False)
+        assert ok2 is True
+
+    def test_custom_thresholds(self):
+        entry = self._ready_entry()
+        # Crank threshold above the entry's paper fitness.
+        ok, _ = eligible_for_live(entry, fitness_threshold=0.99)
+        assert ok is False
+        # Custom min_paper_days that the entry passes (3 weeks).
+        ok2, _ = eligible_for_live(entry, min_paper_days=21)
+        # Entry has 24-day window; 21 < 24 so this passes.
+        assert ok2 is True
+
+
+class TestSchemaMigration:
+    """Pool DBs created before paper_trading_* columns existed must be
+    silently upgraded on open. Construct an old-shape DB by hand, then
+    let StrategyPool.__init__ run migrations."""
+
+    def _create_old_pool(self, path) -> str:
+        """Build a v1-schema DB (pre paper_trading columns) and seed it
+        with one row. Returns the inserted id."""
+        conn = sqlite3.connect(path)
+        conn.execute("""
+            CREATE TABLE strategies (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                source_code TEXT NOT NULL,
+                parent_id TEXT,
+                generation INTEGER NOT NULL DEFAULT 0,
+                fitness_composite REAL NOT NULL DEFAULT 0.0,
+                fitness_json TEXT NOT NULL DEFAULT '{}',
+                backtest_period_start TEXT,
+                backtest_period_end TEXT,
+                walkforward_period_start TEXT,
+                walkforward_period_end TEXT,
+                walkforward_fitness REAL NOT NULL DEFAULT 0.0,
+                status TEXT NOT NULL DEFAULT 'candidate',
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                notes TEXT NOT NULL DEFAULT ''
+            )
+        """)
+        sid = "v1-row-id"
+        conn.execute("""
+            INSERT INTO strategies (
+                id, name, source_code, walkforward_fitness, status,
+                created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+        """, (sid, "legacy", "# legacy code", 0.42, "validated",
+              "2025-06-01T00:00:00", "2025-06-01T00:00:00"))
+        conn.commit()
+        conn.close()
+        return sid
+
+    def test_migration_adds_columns(self, tmp_path):
+        path = tmp_path / "old_pool.db"
+        sid = self._create_old_pool(str(path))
+
+        # Sanity: confirm the column doesn't exist yet.
+        conn = sqlite3.connect(path)
+        cols = {row[1] for row in conn.execute("PRAGMA table_info(strategies)")}
+        conn.close()
+        assert "paper_trading_fitness" not in cols
+
+        # Opening with StrategyPool runs the migration.
+        pool = StrategyPool(path)
+
+        conn = sqlite3.connect(path)
+        cols = {row[1] for row in conn.execute("PRAGMA table_info(strategies)")}
+        conn.close()
+        assert "paper_trading_fitness" in cols
+        assert "paper_trading_period_start" in cols
+        assert "paper_trading_period_end" in cols
+        assert "paper_trading_trades" in cols
+
+        # Legacy row survives, paper fields default-populated.
+        loaded = pool.get(sid)
+        assert loaded is not None
+        assert loaded.name == "legacy"
+        assert loaded.walkforward_fitness == pytest.approx(0.42)
+        assert loaded.paper_trading_fitness == 0.0
+        assert loaded.paper_trading_trades == 0
+        assert loaded.paper_trading_period_start is None
+
+    def test_migration_is_idempotent(self, tmp_path):
+        """Running __init__ twice on an already-migrated DB should not
+        raise (PRAGMA-guard prevents double ADD COLUMN)."""
+        path = tmp_path / "twice.db"
+        StrategyPool(path)
+        StrategyPool(path)  # second open
+        # And a third for good measure.
+        pool = StrategyPool(path)
+        # Pool is usable.
+        pool.add(make_entry())
+        assert pool.count() == 1

--- a/tests/test_reconnect_regression.py
+++ b/tests/test_reconnect_regression.py
@@ -1,0 +1,260 @@
+"""Regression tests for the three reconnect bugs found in bot 0422.
+
+These are source-level pins for invariants that don't lend themselves to
+runtime testing — exercising them properly requires Tkinter, comtypes,
+and a live SKCOM session. The pins are tight enough to detect regressions
+without re-running real reconnect flows.
+
+Bugs covered:
+
+* **Bug A** — premature "connected" on Quote (3002). ``_on_reconnected``
+  must only fire on Ready (3003), and a Quote (3002) without a follow-up
+  Ready must schedule a watchdog timer.
+
+* **Bug B** — no COM teardown before re-login. ``_attempt_reconnect``
+  must call ``SKQuoteLib_LeaveMonitor`` AND ``SKCenterLib_LogOut`` before
+  the fresh ``LoginSetQuote``.
+
+* **Bug C** — watchdog "warn" handler bypasses the resubscribe/reconnect
+  ladder. The handler must require TWO consecutive bad ``IsConnected()``
+  readings before forcing a disconnect, tracked via
+  ``_warn_disconnect_count``.
+
+Also pins the logging-tag prefixes the next debugging session is expected
+to rely on (``[CONN]``, ``[RECONNECT]``, ``[TICKS]``, ``[WATCHDOG]``,
+``[STATE]``).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+
+import pytest
+
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+RB_PATH = os.path.join(PROJECT_ROOT, "run_backtest.py")
+
+
+@pytest.fixture(scope="module")
+def rb_source() -> str:
+    with open(RB_PATH, encoding="utf-8") as f:
+        return f.read()
+
+
+# ---------------------------------------------------------------------------
+# Bug A — Quote (3002) is intermediate; only Ready (3003) marks connected
+# ---------------------------------------------------------------------------
+
+class TestBugA_QuoteIsIntermediate:
+
+    def test_quote_branch_does_not_call_on_reconnected(self, rb_source: str):
+        """Bug A: the `data == "quote"` branch in `_drain_ui_queue` must
+        not call `_on_reconnected()` and must not set `_quote_connected = True`.
+
+        The pre-bug code did both, which fired `_resubscribe_ticks()` on a
+        half-connected session that produced zombie subscriptions.
+        """
+        # Find the "quote" branch — everything between `elif data == "quote"`
+        # and the next `elif data ==` or end of the surrounding block.
+        match = re.search(
+            r'elif data == "quote".*?(?=\n\s{20}elif data ==|\n\s{16}elif kind ==)',
+            rb_source,
+            re.DOTALL,
+        )
+        assert match, "could not locate `elif data == \"quote\"` branch"
+        branch = match.group(0)
+        assert "_on_reconnected" not in branch, (
+            "Bug A regression: Quote (3002) branch still calls "
+            "_on_reconnected; only Ready (3003) should fire it.")
+        assert "_quote_connected = True" not in branch, (
+            "Bug A regression: Quote (3002) branch sets "
+            "_quote_connected = True; only Ready (3003) should.")
+
+    def test_quote_branch_schedules_ready_timeout(self, rb_source: str):
+        """The Quote branch must hand off to a method that arms a
+        Ready (3003) watchdog timer."""
+        assert "_on_quote_intermediate" in rb_source, (
+            "Bug A: Quote (3002) branch should delegate to "
+            "_on_quote_intermediate which schedules a Ready timeout")
+
+    def test_quote_ready_timeout_handler_exists(self, rb_source: str):
+        assert "_on_quote_ready_timeout" in rb_source, (
+            "Bug A: missing _on_quote_ready_timeout handler — without "
+            "this a half-connected session would sit silently forever.")
+
+    def test_quote_intermediate_arms_15s_timer(self, rb_source: str):
+        """The Quote→Ready timer should fire after ~15s."""
+        match = re.search(
+            r"def _on_quote_intermediate\(self\).*?self\.root\.after\(\s*(\d+)",
+            rb_source,
+            re.DOTALL,
+        )
+        assert match, "could not find timer arm in _on_quote_intermediate"
+        delay_ms = int(match.group(1))
+        assert 5000 <= delay_ms <= 30000, (
+            f"Bug A: Ready timeout {delay_ms}ms is outside the "
+            "5-30s window from the issue spec.")
+
+
+# ---------------------------------------------------------------------------
+# Bug B — clean COM state before re-login
+# ---------------------------------------------------------------------------
+
+class TestBugB_CleanupBeforeRelogin:
+
+    def _attempt_reconnect_body(self, rb_source: str) -> str:
+        match = re.search(
+            r"def _attempt_reconnect\(self\):(.*?)\n    def ",
+            rb_source,
+            re.DOTALL,
+        )
+        assert match, "could not locate _attempt_reconnect body"
+        return match.group(1)
+
+    def test_leave_monitor_called_before_login(self, rb_source: str):
+        body = self._attempt_reconnect_body(rb_source)
+        leave_pos = body.find("SKQuoteLib_LeaveMonitor")
+        login_pos = body.find("SKCenterLib_LoginSetQuote")
+        assert leave_pos != -1, (
+            "Bug B: _attempt_reconnect must call SKQuoteLib_LeaveMonitor "
+            "to tear down the prior COM session before re-login.")
+        assert login_pos != -1, "LoginSetQuote unexpectedly removed"
+        assert leave_pos < login_pos, (
+            "Bug B: LeaveMonitor must happen BEFORE LoginSetQuote.")
+
+    def test_logout_called_before_login(self, rb_source: str):
+        body = self._attempt_reconnect_body(rb_source)
+        logout_pos = body.find("SKCenterLib_LogOut")
+        login_pos = body.find("SKCenterLib_LoginSetQuote")
+        assert logout_pos != -1, (
+            "Bug B: _attempt_reconnect must call SKCenterLib_LogOut "
+            "before re-login to ensure a clean COM state.")
+        assert logout_pos < login_pos, (
+            "Bug B: LogOut must happen BEFORE LoginSetQuote.")
+
+    def test_cleanup_calls_swallow_errors(self, rb_source: str):
+        """Cleanup calls must be best-effort — a prior session may already
+        be half-torn-down."""
+        body = self._attempt_reconnect_body(rb_source)
+        # Each cleanup call should be inside its own try/except
+        for fn in ("SKQuoteLib_LeaveMonitor", "SKCenterLib_LogOut"):
+            # Match `try:` ... fn ... `except` within 5 lines
+            pat = rf"try:\s*\n[^\n]*{fn}[^\n]*\n(?:[^\n]*\n){{0,5}}\s*except"
+            assert re.search(pat, body), (
+                f"Bug B: {fn} must be wrapped in try/except so a partial "
+                "tear-down does not abort the reconnect attempt.")
+
+
+# ---------------------------------------------------------------------------
+# Bug C — watchdog warn handler must not shortcut the ladder
+# ---------------------------------------------------------------------------
+
+class TestBugC_WarnLadderRespected:
+
+    def _warn_branch(self, rb_source: str) -> str:
+        # Grab everything inside `elif action == "warn":` until the next
+        # `def ` (method boundary).
+        match = re.search(
+            r'elif action == "warn":(.*?)\n    def ',
+            rb_source,
+            re.DOTALL,
+        )
+        assert match, "could not locate `elif action == \"warn\"` branch"
+        return match.group(1)
+
+    def test_warn_branch_uses_consecutive_counter(self, rb_source: str):
+        warn = self._warn_branch(rb_source)
+        assert "_warn_disconnect_count" in warn, (
+            "Bug C: warn handler must use a consecutive-bad-read counter "
+            "(self._warn_disconnect_count) rather than disconnecting on "
+            "the first IsConnected()!=1 reading.")
+
+    def test_warn_branch_requires_two_consecutive(self, rb_source: str):
+        """The disconnect short-circuit must require >= 2 consecutive bad reads."""
+        warn = self._warn_branch(rb_source)
+        # Look for the threshold check — must be >= 2 or > 1.
+        assert re.search(r"_warn_disconnect_count\s*>=?\s*2", warn) \
+            or re.search(r"_warn_disconnect_count\s*>\s*1", warn), (
+            "Bug C: warn handler must require AT LEAST 2 consecutive "
+            "IsConnected()!=1 reads before forcing disconnect.")
+
+    def test_warn_branch_does_not_call_on_disconnected_unconditionally(
+            self, rb_source: str):
+        """The pre-bug code called `_on_disconnected()` directly inside the
+        try-block right after one bad read. The fix must guard that call
+        behind the counter threshold.
+        """
+        warn = self._warn_branch(rb_source)
+        # Find the `_on_disconnected` call site(s) inside warn.
+        # Each call must be preceded by the counter check on the same path.
+        # Simplest pin: between the IsConnected() call and the _on_disconnected
+        # call, the counter check must appear.
+        ic_idx = warn.find("skQ.SKQuoteLib_IsConnected()")
+        disc_idx = warn.find("self._on_disconnected()")
+        assert ic_idx != -1, "IsConnected() probe missing from warn branch"
+        assert disc_idx != -1, "_on_disconnected() call missing from warn branch"
+        between = warn[ic_idx:disc_idx]
+        assert "_warn_disconnect_count" in between, (
+            "Bug C: _on_disconnected() must be guarded by "
+            "_warn_disconnect_count check, not called on every bad read.")
+
+    def test_warn_counter_reset_on_real_tick(self, rb_source: str):
+        """A real tick is the strongest signal that the connection is alive
+        — it must reset the warn counter so transient bad reads from
+        earlier don't accumulate forever."""
+        # _on_com_tick should reset _warn_disconnect_count
+        match = re.search(
+            r"def _on_com_tick\(.*?(?=\n    def )",
+            rb_source,
+            re.DOTALL,
+        )
+        assert match, "could not locate _on_com_tick"
+        body = match.group(0)
+        assert "_warn_disconnect_count" in body, (
+            "Bug C: _on_com_tick must reset _warn_disconnect_count when "
+            "a real tick arrives.")
+
+
+# ---------------------------------------------------------------------------
+# Logging — pin the structured tag prefixes
+# ---------------------------------------------------------------------------
+
+class TestStructuredLoggingTags:
+
+    @pytest.mark.parametrize("tag", ["[CONN]", "[RECONNECT]", "[TICKS]",
+                                     "[WATCHDOG]", "[STATE]"])
+    def test_tag_present(self, rb_source: str, tag: str):
+        """Every structured tag prefix the spec requires must appear in
+        the source — a debugger should be able to ``grep '\\[CONN\\]'`` and
+        get a useful slice of the log."""
+        assert tag in rb_source, (
+            f"Logging tag {tag} not found in run_backtest.py — the next "
+            "debugging session won't be able to filter by it.")
+
+    def test_log_debug_helper_exists(self, rb_source: str):
+        assert "def _log_debug(" in rb_source, (
+            "Missing _log_debug helper — DEBUG-level structured logging "
+            "should go through a single helper so file capture and the "
+            "[DEBUG] prefix stay consistent.")
+
+    def test_log_debug_includes_wallclock(self, rb_source: str):
+        """Per spec, every line should include wall-clock timestamp."""
+        match = re.search(
+            r"def _log_debug\(.*?(?=\n\s*\ndef )",
+            rb_source,
+            re.DOTALL,
+        )
+        assert match, "could not locate _log_debug body"
+        body = match.group(0)
+        assert "_taipei_now" in body and "datetime.now" in body, (
+            "_log_debug must emit BOTH Taipei and local wall-clock times "
+            "so cross-region correlation works.")
+
+    def test_set_quote_connected_helper(self, rb_source: str):
+        """_quote_connected must be mutated through a helper so every
+        transition is logged."""
+        assert "def _set_quote_connected(" in rb_source, (
+            "Missing _set_quote_connected helper — direct assignment of "
+            "self._quote_connected loses the state-transition log line.")


### PR DESCRIPTION
## Summary

Fixes the persistent reconnect regression seen in bot session **0422**. Three bugs combined to turn a healthy session into a zombie that never recovered, and the existing logs didn't make it easy to figure out which leg failed first. This PR fixes all three and adds DEBUG-level structured logging so the next post-mortem can be done from the session log alone.

### Bug A — premature \"connected\" on Quote (3002)
`OnConnection`'s handler treated both **Ready (3003)** *and* **Quote (3002)** as fully connected and called `_on_reconnected` immediately. Per `CLAUDE.md` the proper sequence is `Reply(3001) → Quote(3002) → Ready(3003)`; 3002 alone is intermediate. When the bot only got `Reply → Quote` (no Ready) it re-issued `RequestTicks` on a half-connected session that returned OK but never delivered ticks — the **zombie subscription** at the heart of 0422.

**Fix:** only Ready (3003) calls `_on_reconnected`. Quote (3002) arms a 15-second watchdog timer (`_on_quote_ready_timeout`); if Ready never arrives, the timer logs a warning and triggers a fresh reconnect cycle.

### Bug B — no COM teardown before re-login
`_attempt_reconnect` called `LoginSetQuote → ConnectByID → EnterMonitor` on top of a broken session without first calling `SKQuoteLib_LeaveMonitor` + `SKCenterLib_LogOut`. The server then reached Quote without ever sending Ready (Bug A's zombie pattern).

**Fix:** best-effort `LeaveMonitor` + `LogOut` calls at the start of every reconnect attempt (errors swallowed — the prior session may already be half-torn-down). `_logged_in` flips to False so the fresh-login path runs cleanly.

### Bug C — watchdog warn handler bypassed the ladder
`_check_tick_watchdog`'s `warn` branch called `SKQuoteLib_IsConnected()` and on any non-1 reading immediately invoked `_on_disconnected()` — bypassing the resubscribe→reconnect ladder `TickWatchdog` was designed to drive. In 0422 this fired at the 2-minute warn mark during the zombie window and kicked off a cascade.

**Fix:** track consecutive bad reads in `_warn_disconnect_count`. The shortcut requires **two consecutive** `IsConnected != 1` reads (~30 s apart on the existing `_schedule_status_update` cadence) before forcing disconnect. Real ticks and a successful Ready both reset the counter.

## Diagnostic logging

New `_log_debug()` helper: wall-clock TPE + local timestamp, `[DEBUG]` prefix, captured to the per-session debug file but **not** pushed into the user-facing live event log widget. Tag prefixes the next debugger can grep:

| Tag | Where | What it tells you |
|---|---|---|
| `[CONN]` | every `OnConnection` event | kind code + plain-English meaning |
| `[RECONNECT]` | each attempt | cleanup → `LoginSetQuote(code)` → waiting for Ready → SUCCESS/FAIL |
| `[TICKS]` | resubscribe path | `RequestTicks` return code, first-tick latency, zombie-subscription warning at >60 s |
| `[WATCHDOG]` | every 30 s check | elapsed / action / `_warn_disconnect_count` snapshot |
| `[STATE]` | every mutation | `_quote_connected` and `ConnectionMonitor` transitions with caller |

`_set_quote_connected(value, caller)` centralises the mutation so every transition produces a `[STATE]` line.

## Regression tests

`tests/test_reconnect_regression.py` — 19 source-level pins for all three fixes plus the structured-log tag prefixes. These pin invariants that would otherwise need Tkinter + comtypes + a live SKCOM session to test.

## Test plan

- [x] `pytest tests/` — 1090 passed (was 1071; adds 19 new regression tests)
- [x] `python -c \"import ast; ast.parse(open('run_backtest.py').read())\"` — parses cleanly
- [ ] Smoke: deploy a bot in paper mode, force a disconnect (kill quote session), confirm `[RECONNECT]` lifecycle lines appear in `debug_YYYYMMDD.log` and the bot recovers
- [ ] Smoke: confirm that on a clean Login → Reply(3001) → Quote(3002) → Ready(3003) sequence, the `[CONN]` lines appear in order and `_on_reconnected` fires only after Ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)