### PR TITLE
feat(ai): ultra_mode tier + conversation auto-truncation

### DIFF
--- a/run_backtest.py
+++ b/run_backtest.py
@@ -291,7 +291,8 @@ def _load_settings():
 
 
 def _save_ai_settings(provider: str = "", anthropic_key: str = "",
-                      google_key: str = "", model: str = "", max_tokens: int = 0):
+                      google_key: str = "", model: str = "", max_tokens: int = 0,
+                      ultra_mode: bool | None = None):
     """Persist AI settings to settings.yaml."""
     if not yaml:
         return
@@ -311,6 +312,10 @@ def _save_ai_settings(provider: str = "", anthropic_key: str = "",
         ai["model"] = model
     if max_tokens:
         ai["max_tokens"] = max_tokens
+    # bool needs an explicit None-check — `if ultra_mode:` could never
+    # persist False, leaving a stale `true` in settings.yaml forever.
+    if ultra_mode is not None:
+        ai["ultra_mode"] = bool(ultra_mode)
     with open(path, "w", encoding="utf-8") as f:
         yaml.dump(data, f, default_flow_style=False, allow_unicode=True)
 
@@ -1949,7 +1954,7 @@ class BacktestApp:
         """Show settings dialog with provider selection and API keys."""
         dialog = tk.Toplevel(self.root)
         dialog.title("AI Settings")
-        dialog.geometry("450x280")
+        dialog.geometry("450x330")
         dialog.resizable(False, False)
         dialog.transient(self.root)
         dialog.grab_set()
@@ -1994,23 +1999,39 @@ class BacktestApp:
         provider_var.trace_add("write", _update_hint)
         _update_hint()
 
+        # Ultra mode — heavy-tier calls (codegen, trade review, Pine
+        # export) use the most capable model. Read per-call from
+        # self._settings, so toggling applies immediately. Google only;
+        # env ULTRA_MODE still wins at next startup.
+        ultra_var = tk.BooleanVar(value=self._settings.get("ultra_mode", False))
+        ttk.Checkbutton(
+            frame, variable=ultra_var,
+            text=f"Ultra Mode — 重要呼叫用最強模型 ({GOOGLE_MODEL_ULTRA}, Google only)",
+        ).grid(row=5, column=0, columnspan=2, sticky=tk.W, pady=(8, 0))
+        ttk.Label(
+            frame, foreground="gray",
+            text="影響: 產生策略 codegen / AI檢視 review / Pine 匯出 export (成本較高 costs more)",
+        ).grid(row=6, column=0, columnspan=2, sticky=tk.W)
+
         # Buttons
         btn_frame = ttk.Frame(frame)
-        btn_frame.grid(row=5, column=0, columnspan=2, pady=(16, 0))
+        btn_frame.grid(row=7, column=0, columnspan=2, pady=(16, 0))
 
         def _save():
             provider = provider_var.get()
             ak = anth_var.get().strip()
             gk = goog_var.get().strip()
             model = model_var.get().strip()
+            ultra = bool(ultra_var.get())
 
             self._settings["ai_provider"] = provider
             self._settings["anthropic_api_key"] = ak
             self._settings["google_api_key"] = gk
             self._settings["ai_model"] = model
+            self._settings["ultra_mode"] = ultra
 
             _save_ai_settings(provider=provider, anthropic_key=ak,
-                              google_key=gk, model=model)
+                              google_key=gk, model=model, ultra_mode=ultra)
 
             # Reset client so it picks up new settings
             if self._chat_client:

--- a/run_backtest.py
+++ b/run_backtest.py
@@ -78,7 +78,8 @@ from src.strategy.examples.m1_sma_cross import M1SmaCrossStrategy
 # AI modules
 from src.ai.chat_client import (
     ChatClient, PROVIDER_ANTHROPIC, PROVIDER_GOOGLE, DEFAULT_MODELS,
-    model_for_tier,
+    GOOGLE_MODEL_PRO, GOOGLE_MODEL_ULTRA,
+    model_for_tier, resolve_ultra_mode,
 )
 from src.ai.prompts import STRATEGY_SYSTEM_PROMPT, STRATEGY_CODE_CONTEXT, CODE_GEN_SYSTEM_PROMPT, CHAT_RECAP_PROMPT
 from src.ai.code_sandbox import (
@@ -272,6 +273,15 @@ def _load_settings():
             cfg["ai_model"] = ai.get("model", "")
             cfg["ai_max_tokens"] = ai.get("max_tokens", 16384)
             cfg["recap_token_gate"] = ai.get("recap_token_gate", 30)
+            # ultra_mode: settings.yaml ai.ultra_mode (default False); env
+            # ULTRA_MODE=1 overrides at runtime.  When ON, "heavy" tier callers
+            # (codegen, trade review, pine export) get the ultra model instead
+            # of gemini-2.5-pro.
+            cfg["ultra_mode"] = resolve_ultra_mode(ai.get("ultra_mode", False))
+            if cfg["ultra_mode"]:
+                print(f"[AI] ultra_mode=ON — heavy tier using {GOOGLE_MODEL_ULTRA}")
+            else:
+                print(f"[AI] ultra_mode=OFF — heavy tier using {GOOGLE_MODEL_PRO}")
             # Notifications
             notif = data.get("notifications", {})
             cfg["discord_bot_token"] = notif.get("discord_bot_token", "")
@@ -1626,7 +1636,8 @@ class BacktestApp:
         # Use a one-shot API call (not the chat conversation) to avoid bloat
         client = self._chat_client
         codegen_model = model_for_tier(
-            self._settings.get("ai_provider", PROVIDER_ANTHROPIC), "heavy")
+            self._settings.get("ai_provider", PROVIDER_ANTHROPIC), "heavy",
+            ultra_mode=self._settings.get("ultra_mode", False))
 
         def _worker():
             try:
@@ -1713,7 +1724,8 @@ class BacktestApp:
         retry_msg = summary_section + error_msg + "\n\n" + STRATEGY_CODE_CONTEXT
         remaining = retries_left - 1
         codegen_model = model_for_tier(
-            self._settings.get("ai_provider", PROVIDER_ANTHROPIC), "heavy")
+            self._settings.get("ai_provider", PROVIDER_ANTHROPIC), "heavy",
+            ultra_mode=self._settings.get("ultra_mode", False))
 
         def _worker():
             try:
@@ -1763,9 +1775,11 @@ class BacktestApp:
 
         source = self._ai_strategy_source
 
+        ultra = self._settings.get("ultra_mode", False)
+
         def _worker():
             try:
-                pine = export_to_pine(self._chat_client, source)
+                pine = export_to_pine(self._chat_client, source, ultra_mode=ultra)
                 self.root.after(0, lambda: self._show_pine_popup(pine))
             except Exception as e:
                 _log(f"Pine export error: [{type(e).__name__}] {e}\n{traceback.format_exc()}")
@@ -3293,7 +3307,8 @@ class BacktestApp:
         self._append_chat("system", f"Analyzing {total_trades} trades...")
 
         review_model = model_for_tier(
-            self._settings.get("ai_provider", PROVIDER_ANTHROPIC), "heavy")
+            self._settings.get("ai_provider", PROVIDER_ANTHROPIC), "heavy",
+            ultra_mode=self._settings.get("ultra_mode", False))
 
         def _worker():
             try:
@@ -3354,7 +3369,8 @@ class BacktestApp:
         )
 
         review_model = model_for_tier(
-            self._settings.get("ai_provider", PROVIDER_ANTHROPIC), "heavy")
+            self._settings.get("ai_provider", PROVIDER_ANTHROPIC), "heavy",
+            ultra_mode=self._settings.get("ultra_mode", False))
 
         def _worker():
             try:

--- a/settings.example.yaml
+++ b/settings.example.yaml
@@ -54,3 +54,7 @@ ai:
   # more than this many messages.  A recap re-sends the full history; on long
   # sessions that's expensive and rarely worth it.
   recap_token_gate: 30
+  # When true, "heavy" tier calls (codegen, trade review, pine export) use the
+  # most capable model (gemini-3.1-pro) instead of gemini-2.5-pro.  Costs more.
+  # Env var ULTRA_MODE=1 overrides this at runtime.
+  ultra_mode: false

--- a/src/ai/chat_client.py
+++ b/src/ai/chat_client.py
@@ -28,8 +28,11 @@ DEFAULT_MODELS = {
 }
 
 # Tiered Gemini models — used by callers that want to pick light vs heavy reasoning.
+# ``ultra`` is reserved for the most capable model; only used when ``ultra_mode``
+# is enabled (via settings.yaml ``ai.ultra_mode`` or env ``ULTRA_MODE=1``).
 GOOGLE_MODEL_PRO = "gemini-2.5-pro"
 GOOGLE_MODEL_FLASH = "gemini-2.5-flash"
+GOOGLE_MODEL_ULTRA = "gemini-3.1-pro"
 
 # Auto-truncate conversation when its total char size exceeds this threshold
 # in send_message().  The first message is always kept; the most recent N
@@ -65,19 +68,66 @@ def _resolve_usage_log_path() -> str:
     return str(Path(__file__).resolve().parents[2] / "data" / "ai_usage.csv")
 
 
-def model_for_tier(provider: str, tier: str) -> str | None:
+def resolve_ultra_mode(settings_value: bool = False) -> bool:
+    """Resolve the effective ultra_mode flag.
+
+    Env var ``ULTRA_MODE`` overrides the settings value when set
+    (``1``/``true``/``yes``/``on`` → True, anything else → False).
+    Otherwise falls back to ``settings_value``.
+    """
+    env = os.environ.get("ULTRA_MODE", "").strip()
+    if env:
+        return env.lower() in ("1", "true", "yes", "on")
+    return bool(settings_value)
+
+
+def model_for_tier(provider: str, tier: str, ultra_mode: bool = False) -> str | None:
     """Return a tier-appropriate model override, or None to use the user default.
 
-    ``tier`` is ``"light"`` (cheap/fast: chat, recap) or ``"heavy"``
-    (quality matters: codegen, trade review).  For non-Google providers we
-    return None so the user-configured model is preserved (Anthropic users pick
-    their own model in settings).
+    ``tier`` is one of:
+      * ``"light"`` — cheap/fast (chat, recap) → always flash
+      * ``"heavy"`` — quality matters (codegen, trade review) → pro by default,
+        or the ultra model when ``ultra_mode`` is True
+      * ``"ultra"`` — always the ultra model (explicit opt-in regardless of flag)
+
+    For non-Google providers we return None so the user-configured model is
+    preserved (Anthropic users pick their own model in settings).
     """
     if provider == PROVIDER_GOOGLE:
         if tier == "light":
             return GOOGLE_MODEL_FLASH
+        if tier == "ultra":
+            return GOOGLE_MODEL_ULTRA
+        # tier == "heavy" (or anything else): respect ultra_mode flag
+        if ultra_mode:
+            return GOOGLE_MODEL_ULTRA
         return GOOGLE_MODEL_PRO
     return None
+
+
+def _classify_model(model: str) -> tuple[str, str]:
+    """Return ``(short_name, mode)`` for the usage-line footer.
+
+    ``short_name`` is a compact tag (flash/pro/sonnet/...).
+    ``mode`` is ``"ultra"`` when the model matches the configured ultra model
+    string, else ``"standard"``.  Derived from the model name so the footer
+    stays in sync with what was actually called, regardless of how the caller
+    resolved tiers.
+    """
+    m = (model or "").lower()
+    if m == GOOGLE_MODEL_ULTRA.lower():
+        return ("pro", "ultra")
+    if "flash" in m:
+        return ("flash", "standard")
+    if "pro" in m:
+        return ("pro", "standard")
+    if "sonnet" in m:
+        return ("sonnet", "standard")
+    if "opus" in m:
+        return ("opus", "standard")
+    if "haiku" in m:
+        return ("haiku", "standard")
+    return (model or "unknown", "standard")
 
 
 def _log_token_usage(
@@ -138,7 +188,8 @@ def _log_token_usage(
 
 
 def _format_usage_line(input_tokens: int, output_tokens: int,
-                       reasoning_tokens: int, total_tokens: int) -> str:
+                       reasoning_tokens: int, total_tokens: int,
+                       model: str = "") -> str:
     """One-line token-usage summary appended to the assistant response so the
     user can see per-call spend in the chat UI without leaving the window.
 
@@ -146,8 +197,12 @@ def _format_usage_line(input_tokens: int, output_tokens: int,
     """
     if total_tokens <= 0:
         return ""
-    return (f"\n\n📊 tokens: {input_tokens:,} in / {output_tokens:,} out / "
+    line = (f"\n\n📊 tokens: {input_tokens:,} in / {output_tokens:,} out / "
             f"{reasoning_tokens:,} reasoning (total: {total_tokens:,})")
+    if model:
+        short, mode = _classify_model(model)
+        line += f" | model: {short} | mode: {mode}"
+    return line
 
 
 def _extract_anthropic_usage(data: dict) -> tuple[int, int, int, int]:
@@ -307,7 +362,7 @@ class ChatClient:
         # Conversation history holds the raw response — the usage line is
         # caller-only so it doesn't bloat future API requests.
         self.conversation.append({"role": "assistant", "content": assistant_text})
-        assistant_text += _format_usage_line(in_tok, out_tok, think_tok, tot_tok)
+        assistant_text += _format_usage_line(in_tok, out_tok, think_tok, tot_tok, used_model)
         return assistant_text
 
     def _send_google(self, user_message: str, *, call_site: str, model: str | None) -> str:
@@ -376,7 +431,7 @@ class ChatClient:
 
         if candidates and candidates[0].get("finishReason") == "MAX_TOKENS":
             assistant_text += "\n\n[WARNING: Response truncated due to token limit]"
-        assistant_text += _format_usage_line(in_tok, out_tok, think_tok, tot_tok)
+        assistant_text += _format_usage_line(in_tok, out_tok, think_tok, tot_tok, used_model)
 
         return assistant_text
 
@@ -444,7 +499,7 @@ class ChatClient:
             input_tokens=in_tok, output_tokens=out_tok,
             reasoning_tokens=think_tok, total_tokens=tot_tok,
         )
-        assistant_text += _format_usage_line(in_tok, out_tok, think_tok, tot_tok)
+        assistant_text += _format_usage_line(in_tok, out_tok, think_tok, tot_tok, used_model)
         return assistant_text
 
     def _one_shot_google(self, user_message: str, system_prompt: str = "",
@@ -492,7 +547,7 @@ class ChatClient:
 
         if candidates and candidates[0].get("finishReason") == "MAX_TOKENS":
             assistant_text += "\n\n[WARNING: Response truncated due to token limit]"
-        assistant_text += _format_usage_line(in_tok, out_tok, think_tok, tot_tok)
+        assistant_text += _format_usage_line(in_tok, out_tok, think_tok, tot_tok, used_model)
 
         return assistant_text
 

--- a/src/ai/pine_exporter.py
+++ b/src/ai/pine_exporter.py
@@ -6,7 +6,8 @@ from .chat_client import ChatClient, model_for_tier
 from .prompts import PINE_EXPORT_SYSTEM_PROMPT
 
 
-def export_to_pine(chat_client: ChatClient, strategy_source: str) -> str:
+def export_to_pine(chat_client: ChatClient, strategy_source: str,
+                   ultra_mode: bool = False) -> str:
     """Translate a Python BacktestStrategy to Pine Script v5.
 
     Uses a one-shot API call with PINE_EXPORT_SYSTEM_PROMPT.
@@ -18,7 +19,7 @@ def export_to_pine(chat_client: ChatClient, strategy_source: str) -> str:
     )
     # Pine translation needs the strategy logic preserved exactly — use the
     # heavy tier so subtle entry/exit conditions don't get paraphrased away.
-    pine_model = model_for_tier(chat_client.provider, "heavy")
+    pine_model = model_for_tier(chat_client.provider, "heavy", ultra_mode=ultra_mode)
     response = chat_client.one_shot(
         prompt, system_prompt=PINE_EXPORT_SYSTEM_PROMPT,
         call_site="pine_export", model=pine_model,

--- a/tests/test_chat_client.py
+++ b/tests/test_chat_client.py
@@ -14,6 +14,7 @@ from src.ai.chat_client import (
     GOOGLE_MODEL_FLASH,
     GOOGLE_MODEL_PRO,
     GOOGLE_MODEL_ULTRA,
+    _CONVERSATION_CHAR_LIMIT,
     _classify_model,
     _format_usage_line,
     model_for_tier,
@@ -569,3 +570,69 @@ class TestBuildSummary:
         assert "C" * 100 in summary
         # Total bounded (budget 8000 for tier A, middle messages get small slices)
         assert len(summary) < 20000
+
+
+# ---------------------------------------------------------------------------
+# Conversation auto-truncation tests
+# ---------------------------------------------------------------------------
+
+class TestConversationAutoTruncation:
+
+    def _make_client(self) -> ChatClient:
+        return ChatClient(api_key="test", provider=PROVIDER_ANTHROPIC)
+
+    def test_no_truncation_under_limit(self):
+        client = self._make_client()
+        client.conversation = [
+            {"role": "user", "content": "short"},
+            {"role": "assistant", "content": "reply"},
+        ]
+        client._enforce_conversation_size()
+        assert len(client.conversation) == 2
+
+    def test_truncation_drops_middle_keeps_first_and_tail(self):
+        client = self._make_client()
+        first_msg = {"role": "user", "content": "FIRST_MSG"}
+        # Build a conversation that exceeds _CONVERSATION_CHAR_LIMIT
+        big = "x" * 50_000
+        client.conversation = [first_msg]
+        for i in range(10):
+            client.conversation.append({"role": "assistant", "content": big})
+            client.conversation.append({"role": "user", "content": big})
+        client.conversation.append({"role": "assistant", "content": "LAST_MSG"})
+
+        original_len = len(client.conversation)
+        client._enforce_conversation_size()
+
+        # Should have dropped some middle messages
+        assert len(client.conversation) < original_len
+        # First message preserved
+        assert client.conversation[0]["content"] == "FIRST_MSG"
+        # Last message preserved
+        assert client.conversation[-1]["content"] == "LAST_MSG"
+
+    def test_truncation_preserves_alternating_roles(self):
+        """After truncation the conversation should still make sense —
+        the first message is kept and the tail is kept as-is."""
+        client = self._make_client()
+        # Each message ~25K chars, 10 pairs = ~500K total
+        chunk = "a" * 25_000
+        client.conversation = [{"role": "user", "content": "FIRST"}]
+        for i in range(10):
+            client.conversation.append({"role": "assistant", "content": chunk})
+            client.conversation.append({"role": "user", "content": chunk})
+
+        client._enforce_conversation_size()
+
+        total_chars = sum(len(m.get("content", "")) for m in client.conversation)
+        assert total_chars <= _CONVERSATION_CHAR_LIMIT + 25_000  # one msg can push over
+
+    def test_two_message_conversation_never_truncated(self):
+        """A 2-message conversation is never truncated even if huge."""
+        client = self._make_client()
+        client.conversation = [
+            {"role": "user", "content": "x" * 300_000},
+            {"role": "assistant", "content": "y" * 300_000},
+        ]
+        client._enforce_conversation_size()
+        assert len(client.conversation) == 2

--- a/tests/test_chat_client.py
+++ b/tests/test_chat_client.py
@@ -5,10 +5,19 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+import os
+
 from src.ai.chat_client import (
     ChatClient,
     PROVIDER_ANTHROPIC,
     PROVIDER_GOOGLE,
+    GOOGLE_MODEL_FLASH,
+    GOOGLE_MODEL_PRO,
+    GOOGLE_MODEL_ULTRA,
+    _classify_model,
+    _format_usage_line,
+    model_for_tier,
+    resolve_ultra_mode,
 )
 
 
@@ -318,6 +327,109 @@ class TestChatClientGeneral:
 
         payload = client._client.post.call_args[1]["json"]
         assert "system" not in payload
+
+
+# ---------------------------------------------------------------------------
+# Model tiering + ultra_mode tests
+# ---------------------------------------------------------------------------
+
+class TestModelForTier:
+
+    def test_light_always_flash(self):
+        assert model_for_tier(PROVIDER_GOOGLE, "light") == GOOGLE_MODEL_FLASH
+        assert model_for_tier(PROVIDER_GOOGLE, "light", ultra_mode=True) == GOOGLE_MODEL_FLASH
+
+    def test_heavy_standard_returns_pro(self):
+        assert model_for_tier(PROVIDER_GOOGLE, "heavy") == GOOGLE_MODEL_PRO
+        assert model_for_tier(PROVIDER_GOOGLE, "heavy", ultra_mode=False) == GOOGLE_MODEL_PRO
+
+    def test_heavy_with_ultra_mode_returns_ultra(self):
+        assert model_for_tier(PROVIDER_GOOGLE, "heavy", ultra_mode=True) == GOOGLE_MODEL_ULTRA
+
+    def test_ultra_tier_always_ultra(self):
+        # Explicit ultra tier ignores the ultra_mode flag.
+        assert model_for_tier(PROVIDER_GOOGLE, "ultra") == GOOGLE_MODEL_ULTRA
+        assert model_for_tier(PROVIDER_GOOGLE, "ultra", ultra_mode=False) == GOOGLE_MODEL_ULTRA
+
+    def test_non_google_provider_returns_none(self):
+        # Anthropic users pick their own model in settings; tier resolution
+        # must not override it.
+        assert model_for_tier(PROVIDER_ANTHROPIC, "light") is None
+        assert model_for_tier(PROVIDER_ANTHROPIC, "heavy", ultra_mode=True) is None
+
+
+class TestResolveUltraMode:
+
+    def setup_method(self):
+        self._saved_env = os.environ.pop("ULTRA_MODE", None)
+
+    def teardown_method(self):
+        os.environ.pop("ULTRA_MODE", None)
+        if self._saved_env is not None:
+            os.environ["ULTRA_MODE"] = self._saved_env
+
+    def test_default_false(self):
+        assert resolve_ultra_mode() is False
+        assert resolve_ultra_mode(False) is False
+
+    def test_settings_true(self):
+        assert resolve_ultra_mode(True) is True
+
+    def test_env_var_overrides_to_true(self):
+        os.environ["ULTRA_MODE"] = "1"
+        assert resolve_ultra_mode(False) is True
+
+    def test_env_var_overrides_to_false(self):
+        # When settings say True but env explicitly disables, env wins.
+        os.environ["ULTRA_MODE"] = "0"
+        assert resolve_ultra_mode(True) is False
+
+    def test_env_var_truthy_strings(self):
+        for v in ("1", "true", "TRUE", "yes", "on"):
+            os.environ["ULTRA_MODE"] = v
+            assert resolve_ultra_mode(False) is True, f"expected True for {v!r}"
+
+    def test_env_var_empty_falls_back_to_settings(self):
+        os.environ["ULTRA_MODE"] = ""
+        assert resolve_ultra_mode(True) is True
+        assert resolve_ultra_mode(False) is False
+
+
+class TestClassifyModel:
+
+    def test_flash(self):
+        assert _classify_model("gemini-2.5-flash") == ("flash", "standard")
+
+    def test_pro_standard(self):
+        assert _classify_model("gemini-2.5-pro") == ("pro", "standard")
+
+    def test_ultra_model(self):
+        # The ultra model still has "pro" in its name; mode disambiguates.
+        assert _classify_model(GOOGLE_MODEL_ULTRA) == ("pro", "ultra")
+
+    def test_anthropic_sonnet(self):
+        assert _classify_model("claude-sonnet-4-20250514") == ("sonnet", "standard")
+
+
+class TestUsageLineFooter:
+
+    def test_includes_model_and_mode(self):
+        line = _format_usage_line(100, 50, 25, 175, model="gemini-2.5-pro")
+        assert "| model: pro" in line
+        assert "| mode: standard" in line
+
+    def test_ultra_model_shows_ultra_mode(self):
+        line = _format_usage_line(100, 50, 25, 175, model=GOOGLE_MODEL_ULTRA)
+        assert "| model: pro" in line
+        assert "| mode: ultra" in line
+
+    def test_empty_when_total_zero(self):
+        assert _format_usage_line(0, 0, 0, 0, model="gemini-2.5-pro") == ""
+
+    def test_no_model_no_suffix(self):
+        line = _format_usage_line(100, 50, 25, 175)
+        assert "tokens:" in line
+        assert "| model:" not in line
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds a third model tier (`ultra`) so heavy-tier AI calls (codegen, trade review, pine export) can be pointed at `gemini-3.1-pro` on demand without affecting any other call site. Default behavior is unchanged: heavy still resolves to `gemini-2.5-pro`.

Also adds conversation auto-truncation (`_enforce_conversation_size()`) to cap conversation history at 200K chars — prevents the 21K→25K input token bloat seen in June chat calls.

### Cost audit context

Auditing `data/ai_usage.csv`:

| site         | cost share | model           |
|--------------|:----------:|-----------------|
| codegen      | 73 %       | gemini-2.5-pro  |
| trade_review | 26 %       | gemini-2.5-pro  |
| chat         | <1 %       | gemini-2.5-flash |

**Key insight:** codegen + trade_review = ~99% of spend. Chat (flash) is rounding error. `ultra_mode` is the only lever that meaningfully moves total cost.

## Implementation

### Three-tier model system (`model_for_tier`)
- `light` → always `gemini-2.5-flash` (chat, recap)
- `heavy` → `gemini-2.5-pro` (default) or `gemini-3.1-pro` when `ultra_mode=True`
- `ultra` → always `gemini-3.1-pro` (explicit opt-in, ignores the flag)
- Non-Google providers: returns `None` (user-configured Anthropic model preserved)

### `resolve_ultra_mode(settings_value)`
- Reads `ai.ultra_mode` from `settings.yaml` (default `false`)
- `ULTRA_MODE=1` env var overrides at runtime
- Empty env var falls back to the settings value

### Startup log + response footer
- `[AI] ultra_mode=OFF — heavy tier using gemini-2.5-pro` on startup
- `📊 tokens: X in / Y out / Z reasoning (total: N) | model: pro | mode: standard` on every response

### Conversation auto-truncation
- `_enforce_conversation_size()` fires on every `send_message()` call
- Keeps first message (original context) + most recent tail that fits under 200K chars
- Drops middle messages — prevents token bloat from long chat sessions
- 2-message conversations are never truncated

### Wiring
- 5 heavy-tier call sites pass `ultra_mode`: codegen, codegen retry, pine export, trade review, batched trade review
- `export_to_pine()` gained `ultra_mode` parameter
- Light-tier sites (chat, recap) intentionally unchanged

## Test plan
- [x] `resolve_ultra_mode()` — default false, settings true, env var override (truthy/falsy/empty)
- [x] `model_for_tier()` — light→flash, heavy→pro, heavy+ultra→ultra, ultra always ultra, non-Google → None
- [x] `_classify_model()` — flash/pro/ultra/sonnet → (short_name, mode)
- [x] `_format_usage_line()` — model+mode footer, empty when 0, no suffix when unset
- [x] `_enforce_conversation_size()` — no truncation under limit, drops middle, preserves first+tail, 2-msg immunity
- [x] Full test suite: **1113 passed**
- [ ] Smoke: launch `run_backtest.py`, confirm `[AI] ultra_mode=OFF` prints
- [ ] Smoke: set `ULTRA_MODE=1`, confirm codegen routes to `gemini-3.1-pro`

🤖 Generated with [Claude Code](https://claude.com/claude-code)