### PR TITLE
fix(evolution): notify on all silent auto-evolution skip paths (#74)

### DIFF
--- a/run_backtest.py
+++ b/run_backtest.py
@@ -3840,9 +3840,26 @@ class BacktestApp:
             omitted = 0  # full design-history re-run; cut unchanged
         sent_lines = trade_lines[omitted:cut_idx]
         if not sent_lines:
+            msg = (f"🧬 EVO: 訓練窗沒有交易（資料太新，全部 "
+                   f"{len(trade_lines)} 筆交易都在最近 {holdout_days} 天"
+                   f"保留測試集內）。機器人需運行超過 {holdout_days} 天，"
+                   f"交易才會進入設計窗供 AI 分析。"
+                   f"No design-window trades yet — all {len(trade_lines)} "
+                   f"trades are inside the {holdout_days}d holdout. "
+                   f"The bot needs to run for >{holdout_days} days before "
+                   f"trades age into the design window for AI analysis.")
             self.status_var.set(
                 "🧬 EVO: 訓練窗沒有交易（資料太新）No design-window trades "
                 "yet — session younger than the holdout.")
+            if auto_run:
+                self._append_chat("system", msg)
+                if _discord is not None and _discord.enabled:
+                    try:
+                        _discord.notify(msg)
+                    except Exception:
+                        pass
+            else:
+                self._append_chat("system", msg)
             return
 
         # Rebuild the metrics report from design-known trades only — the

--- a/run_backtest.py
+++ b/run_backtest.py
@@ -3771,7 +3771,16 @@ class BacktestApp:
         """
         payload = self._gather_analysis_payload()
         if payload is None:
+            msg = ("🧬 EVO: 無交易紀錄，演化引擎無資料可分析。"
+                   "No trades recorded — evolution has no data to analyze.")
             self.status_var.set("無交易紀錄 No trades for evolution")
+            if auto_run:
+                self._append_chat("system", msg)
+                if _discord is not None and _discord.enabled:
+                    try:
+                        _discord.notify(msg)
+                    except Exception:
+                        pass
             return
         if not self._ensure_chat_client():
             return
@@ -5267,7 +5276,13 @@ class BacktestApp:
         try:
             self._bot_evolution(auto_run=True)
         except Exception as e:
-            _log(f"weekly auto-evolution failed: [{type(e).__name__}] {e}")
+            err_msg = f"weekly auto-evolution failed: [{type(e).__name__}] {e}"
+            _log(err_msg)
+            if _discord is not None and _discord.enabled:
+                try:
+                    _discord.notify(f"🧬 EVO ERROR: {err_msg}")
+                except Exception:
+                    pass
 
     def _check_tick_watchdog(self):
         """Delegate tick health check to TickWatchdog and act on the result."""


### PR DESCRIPTION
## Summary
- When evolution skips due to empty design window (all trades in holdout), sends bilingual chat + Discord notification
- When evolution skips due to no trades at all (`payload is None`), sends bilingual chat + Discord notification on auto_run
- When weekly auto-evolution crashes, sends Discord alert (previously only logged)

Fixes #74

## Test plan
- [ ] Deploy bot with <14 days of data → verify Discord notification fires on weekly evolution
- [ ] Deploy bot with no trades → verify "no data to analyze" notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)