### PR TITLE
docs(ai): clarify close() vs exit() fill semantics in code-gen context (#75)

### DIFF
--- a/src/ai/prompts.py
+++ b/src/ai/prompts.py
@@ -193,7 +193,19 @@ Use this for loss counting: `broker.trades[-1].pnl < 0` — do NOT compare bar.c
   exchange fill via OpenInterest. Prefer `effective_entry_price()` for stop math.
 - **IMPORTANT**: `entry()` returns None — do NOT store its return value. Track position state with `broker.position_size` and use the tag string literal in close()/exit().
 - **IMPORTANT**: `exit()` REQUIRES limit and/or stop prices to work. exit() with no limit/stop does NOTHING.
-  Use `close()` for immediate market exits (e.g. when checking bar.high >= target in on_bar).
+- **`close()` vs `exit()` — choose by how the exit must fill:**
+  - `broker.close(from_entry, tag)` is **market-on-close**: it fills at THIS bar's close and is only
+    evaluated when `on_bar()` runs (once per bar). Use it for session-close exits and discretionary
+    "flatten now" exits — NOT for stop-losses.
+  - `broker.exit(tag, from_entry, stop=X, limit=Y)` is a **resting order**: in live mode it is checked
+    on EVERY tick and fills the instant price touches the level (a stop fills at the tick price); in
+    backtest it is matched against the bar's full OHLC at the stop/limit price. Use it for stop-losses
+    and take-profits you want executed the moment price reaches them.
+  - **Stop-loss anti-pattern (do NOT do this):** `if bar.high >= stop: broker.close(...)`. A manual
+    bar-level check runs only when the bar completes and fills at the bar's close, so an intra-bar
+    spike through the stop is not acted on until the bar closes — losing all intra-bar protection.
+    Place `broker.exit(stop=X)` at entry instead (see the entry/exit pairing rule below) so the live
+    tick engine fills it at the stop the instant price gets there.
 - **CRITICAL — Always pair entry() with exit() on the SAME on_bar() call.** \
   In live mode, TP/SL exits are checked on every tick between bars. If exit() \
   is only called on the NEXT bar (after position_size > 0), the exit order \


### PR DESCRIPTION
## Summary

Follow-up to the issue #75 investigation. No strategy or framework code changes — this sharpens the AI **code-generation context** so AI-generated strategies use the correct stop-loss exit mechanism.

## Background

While investigating why `BbandSmaShortV3`'s stop-loss exited at bar close instead of intra-bar, I traced the full live path:

- The strategy's SL was a manual `if bar.high >= stop: broker.close(...)` check.
- `on_bar()` only runs when an aggregated bar **completes** (`live_runner.py:757`), so the stop was evaluated once per bar.
- `broker.close()` is **market-on-close** — it fills at that bar's close (`broker.py:291-298`).
- Meanwhile the live tick engine (`check_tick_exit`, `live_runner.py:591`) runs on **every tick** (`run_backtest.py:5553`) and fills `broker.exit(stop=X)` resting orders at the tick price the instant price crosses the level — but the strategy never placed a resting order, so it was blind to the stop between bars.

**Conclusion:** the framework already provides correct intra-bar stop execution via `broker.exit(stop=X)`. The strategy bypassed it. This is a strategy-authoring issue, not a framework bug.

## Root cause in the prompt

`STRATEGY_CODE_CONTEXT` already tells the AI to place exits at entry so ticks catch them intra-bar, but one line endorsed the exact anti-pattern:

> Use `close()` for immediate market exits (e.g. when checking bar.high >= target in on_bar).

## Change

Replaces that line with explicit guidance:

- `broker.close()` = market-on-close, evaluated once per bar, fills at bar close → session-close / discretionary exits only.
- `broker.exit(stop=, limit=)` = resting order, checked every tick in live and against full OHLC in backtest, fills at the level → stops and targets.
- Explicit **stop-loss anti-pattern** warning steering to `broker.exit(stop=X)` placed at entry.

## Note

This does **not** change issue #75's trade outcomes — in those trades the bar-close fill was coincidentally favorable. The value is correctness/predictability of stop execution for future AI-generated strategies. `atr_sl_mult` tuning remains the strategy author's decision (see diagnostic on #75).

## Testing

- AI/prompt/pine tests: 8 passed
- No behavioral code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)