### PR TITLE
fix(live): repair session-resume force-close, mode tag, and reload freeze (#79)

### DIFF
--- a/run_backtest.py
+++ b/run_backtest.py
@@ -1071,6 +1071,9 @@ class BacktestApp:
         self._live_history_tick_count = 0
         self._live_stale_drops = 0
         self._live_runner.suppress_strategy = True
+        # Issue #79: reconnect re-enters the history-replay window — ignore
+        # mode overrides until the history→live transition clears the flag.
+        self._live_runner._is_reloading = True
         # Track when this RequestTicks fired so we can log latency to first tick
         # (and detect zombie subscriptions where no tick arrives).
         self._ticks_requested_at = time.time()
@@ -4851,6 +4854,35 @@ class BacktestApp:
             n = self._live_runner.restore_session(resume_session)
             self._live_log_msg(f"恢復交易紀錄 Resumed session: {n} trades restored", "status")
 
+            # Issue #79: reconcile the safety guard with the restored position.
+            # guard.reset() (line above at deploy) cleared real_entry_confirmed
+            # and fill_pending, but the restored broker may already hold an
+            # open position from the previous session. Without this, every
+            # exit/force-close is SKIP_EXIT'd (real_entry_confirmed=False) and
+            # any stale fill_pending would BLOCK_FILL_PENDING the close forever
+            # — the live position stays stuck open until the user manually
+            # switches trading modes.
+            if self._live_runner.broker.position_size > 0:
+                cleared = self._trading_guard.restore_confirmed_position()
+                if cleared:
+                    self._live_log_msg(
+                        "[RESUME] Cleared stale fill_pending — position already "
+                        "confirmed from previous session", "status")
+                self._live_log_msg(
+                    "[RESUME] Restored confirmed real position — exits/"
+                    "force-close re-enabled", "status")
+
+            # Issue #79 (sub-problem C): explicitly re-sync the mode tag now,
+            # before warmup/replay begins. The var was set at deploy time, but
+            # re-asserting it here (and guarding _check_mode_override while
+            # _is_reloading) keeps the tag from momentarily blanking during
+            # history replay until a manual mode switch restores it.
+            combo_label = self._mode_key_to_combo.get(
+                self._trading_mode, self._trading_mode)
+            self.trading_mode_var.set(combo_label)
+            self._live_log_msg(
+                f"[RESUME] Trading mode restored: {self._trading_mode}", "status")
+
         # Register callbacks
         self._live_runner.on("on_bar", lambda b: self.root.after(0, self._on_live_bar, b))
         self._live_runner.on("on_decision", lambda d: self.root.after(0, self._on_live_decision, d))
@@ -5027,6 +5059,28 @@ class BacktestApp:
                  f"[{type(e).__name__}] {e}")
         self._start_live_tick_subscription()
 
+    def _on_reload_progress(self, done: int, total: int) -> None:
+        """Progress hook for LiveRunner.reload_1m_bars (issue #79).
+
+        Logs every batch and pumps the Tk event loop so the window stays
+        painted during a long bar reload. Uses update_idletasks() (redraw
+        only) rather than update() on purpose: a full update() would
+        dispatch queued user input — a "Stop Bot" click mid-reload would
+        re-enter _stop_live() and clear self._live_runner underneath the
+        still-running reload, crashing on return. update_idletasks() keeps
+        the UI responsive-looking without that re-entrancy hazard.
+        """
+        if total:
+            self._live_log_msg(
+                f"[RESUME] Reloading bars: {done}/{total}...", "status")
+        else:
+            self._live_log_msg(
+                f"[RESUME] Reloading bars: {done}...", "status")
+        try:
+            self.root.update_idletasks()
+        except Exception:
+            pass  # window may be tearing down — never break the reload
+
     # ── Tick-based live data feed ──
 
     def _start_live_tick_subscription(self):
@@ -5034,8 +5088,14 @@ class BacktestApp:
         if not self._live_runner:
             return
 
-        # Reload saved 1-min bars from CSV (for resumed sessions)
-        n_reloaded = self._live_runner.reload_1m_bars()
+        # Reload saved 1-min bars from CSV (for resumed sessions).
+        # Issue #79: for long-lookback strategies the reload can re-feed
+        # thousands of bars through fresh HTF aggregators in one blocking
+        # call, freezing the UI for seconds. Pass a progress callback that
+        # logs every 500 bars and pumps the Tk event loop so the window
+        # stays painted/responsive during the reload.
+        n_reloaded = self._live_runner.reload_1m_bars(
+            progress_cb=self._on_reload_progress)
         if n_reloaded > 0:
             self._live_log_msg(
                 f"已載入歷史1分K Reloaded {n_reloaded} saved 1m bars from CSV", "status")
@@ -5494,6 +5554,9 @@ class BacktestApp:
             self._live_history_done = True
             self._live_history_tick_count = self._live_tick_count
             self._live_runner.suppress_strategy = False
+            # Issue #79: reloading window is over — live hot-swap mode
+            # overrides may now be honored again.
+            self._live_runner._is_reloading = False
             status = self._live_runner.get_status()
             self._live_log_msg(
                 f"歷史報價完成 History ticks done: {self._live_tick_count} ticks, "

--- a/src/live/live_runner.py
+++ b/src/live/live_runner.py
@@ -379,6 +379,11 @@ class LiveRunner:
         self._warmup_bar_count: int = 0  # count of warmup bars in _aggregated_bars
         self._callbacks: dict[str, list] = {}
         self.suppress_strategy: bool = False  # suppress strategy during history catchup
+        # Issue #79: True from warmup start until history replay completes.
+        # While set, _check_mode_override() is skipped so a stale
+        # mode_override.json (or a race with the resume UI sync) can't flip
+        # the trading mode mid-replay and blank the mode tag.
+        self._is_reloading: bool = False
         self.trading_mode: str = "paper"  # "paper", "semi_auto", or "auto"
         self.broker.trade_source = _mode_to_source(self.trading_mode)
         self.daily_loss_limit: int = 10000  # NTD, for session persistence
@@ -446,6 +451,12 @@ class LiveRunner:
 
     def _check_mode_override(self) -> str | None:
         """Read and consume a mode_override.json file from the bot directory."""
+        # Issue #79: never consume/apply a mode override during warmup or
+        # history replay. Applying one mid-replay races with the resume UI
+        # sync and makes the mode tag disappear until the user manually
+        # switches modes. Live hot-swaps resume once _is_reloading clears.
+        if self._is_reloading:
+            return None
         override_path = os.path.join(self.bot_dir, "mode_override.json")
         try:
             if not os.path.exists(override_path):
@@ -535,6 +546,10 @@ class LiveRunner:
     def feed_warmup_bars(self, kline_strings: list[str]) -> int:
         """Parse historical bars and seed DataStore. Returns bar count loaded."""
         self.state = LiveState.WARMING_UP
+        # Issue #79: warmup + the tick-history replay that follows are the
+        # "reloading" window. Mark it so mode overrides are ignored until
+        # the GUI clears the flag when live ticks begin.
+        self._is_reloading = True
 
         bars = parse_kline_strings(
             kline_strings, symbol=self.symbol, interval=self.target_interval,
@@ -1089,7 +1104,12 @@ class LiveRunner:
         self._started_at = session_data.get("started_at", self._started_at)
         return len(self.broker.trades)
 
-    def reload_1m_bars(self) -> int:
+    # Emit a progress tick every N bars during reload so the GUI can keep
+    # the Tkinter event loop pumping (issue #79 — long-lookback strategies
+    # froze the UI for seconds while thousands of saved bars were re-fed).
+    _RELOAD_PROGRESS_EVERY = 500
+
+    def reload_1m_bars(self, progress_cb: Callable[[int, int], None] | None = None) -> int:
         """Reload saved 1-min bar CSVs into _1m_bars and _seen_1m_dts.
 
         Call AFTER restore_session() and feed_warmup_bars().
@@ -1108,10 +1128,25 @@ class LiveRunner:
         bars but then drops them via the _seen_1m_dts dedup before they
         can reach _aggregated_bars (issue #45).
 
+        ``progress_cb`` (issue #79): optional ``(done, total) -> None`` hook
+        invoked every ``_RELOAD_PROGRESS_EVERY`` bars during the two heavy
+        loops (CSV parse and, for 1-min strategies, the data_store/HTF
+        rebuild). LiveRunner is UI-agnostic, so the GUI passes a callback
+        that logs progress and pumps the Tkinter event loop to stay
+        responsive. ``total`` is 0 while it is not yet known (parse phase).
+        Bars are still fed strictly in order — the callback only observes.
+
         Returns the number of NEW 1-min bars loaded from CSV.
         """
         import csv
         import glob as glob_mod
+
+        def _tick(done: int, total: int) -> None:
+            if progress_cb is not None:
+                try:
+                    progress_cb(done, total)
+                except Exception:
+                    pass  # a broken UI callback must never break the reload
 
         pattern = os.path.join(self.bot_dir, "bars_1m_*.csv")
         csv_files = sorted(glob_mod.glob(pattern))
@@ -1146,6 +1181,9 @@ class LiveRunner:
                             self._seen_1m_dts.add(dt)
                             self._1m_bars.append(bar)
                             new_bars.append(bar)
+                            # total unknown during parse → 0
+                            if len(new_bars) % self._RELOAD_PROGRESS_EVERY == 0:
+                                _tick(len(new_bars), 0)
                         except (ValueError, IndexError):
                             continue
             except OSError:
@@ -1170,8 +1208,11 @@ class LiveRunner:
             from ..market_data.data_store import DataStore
             maxlen = self.data_store._bars.maxlen or 5000
             new_store = DataStore(max_bars=maxlen)
-            for b in merged:
+            total = len(merged)
+            for i, b in enumerate(merged, 1):
                 new_store.add_bar(b)
+                if i % self._RELOAD_PROGRESS_EVERY == 0:
+                    _tick(i, total)
             self.data_store = new_store
             # MTF: rebuild HTF state by re-feeding primary bars through
             # fresh aggregators so backtest/live parity holds across
@@ -1183,8 +1224,10 @@ class LiveRunner:
                     iv: BarAggregator(self.symbol, iv)
                     for iv in self._htf_intervals
                 }
-                for b in merged:
+                for i, b in enumerate(merged, 1):
                     self._feed_htf(b)
+                    if i % self._RELOAD_PROGRESS_EVERY == 0:
+                        _tick(i, total)
             # CSV-loaded bars are historical, not live — bump
             # _warmup_bar_count so get_live_bars() continues to slice
             # off the correct prefix.

--- a/src/live/trading_guard.py
+++ b/src/live/trading_guard.py
@@ -132,6 +132,34 @@ class TradingGuard:
         self.halted = False
         self.halt_reason = ""
 
+    # ── Session resume reconciliation (issue #79) ──
+
+    def restore_confirmed_position(self) -> bool:
+        """Reconcile guard state for a position inherited from a prior session.
+
+        On session resume the bot re-adopts an open position it opened in a
+        previous run (restored via ``broker.from_dict``). That entry was
+        already confirmed last session — no fresh ``on_fill_confirmed`` will
+        arrive from the COM reconnect. Without this reconciliation the guard
+        (which was ``reset()`` on deploy) still believes no real entry exists:
+
+          * ``real_entry_confirmed`` stays False, so every exit / force-close
+            is SKIP_EXIT'd ("no real entry was confirmed") and the live
+            position is stuck open until the user manually switches modes
+            (issue #79 — the reported "平倉單沒帶入" symptom).
+          * any stale ``fill_pending`` (auto mode) would BLOCK_FILL_PENDING the
+            exit and defer it forever, because the entry fill it is waiting on
+            already happened in the previous session.
+
+        Returns True if a stale ``fill_pending`` was cleared (for logging).
+        """
+        had_pending = self.fill_pending
+        self.fill_pending = False
+        self.fill_pending_type = ""
+        self.real_entry_confirmed = True
+        self._deferred_close = None
+        return had_pending
+
     # ── Margin check ──
 
     @staticmethod

--- a/tests/test_live_runner.py
+++ b/tests/test_live_runner.py
@@ -1,7 +1,7 @@
 """Tests for LiveRunner: warmup, feed, dedup, strategy execution, stop."""
 
 import os
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from src.market_data.models import Bar
 from src.market_data.data_store import DataStore
@@ -1085,6 +1085,69 @@ class TestReload1mBarsIssue45:
         runner.reload_1m_bars()
 
         assert runner.data_store._bars.maxlen == original_maxlen
+
+
+# ── Regression: issue #79 — reload progress yields (UI freeze) ──
+
+class TestReload1mBarsProgressIssue79:
+    """reload_1m_bars must report progress so the GUI can pump the Tk event
+    loop and stay responsive while re-feeding thousands of saved bars."""
+
+    @staticmethod
+    def _write_many_bars(path: str, n: int) -> None:
+        base = datetime(2026, 2, 28, 0, 0)
+        with open(path, "w", encoding="utf-8") as f:
+            f.write("datetime,open,high,low,close,volume\n")
+            for i in range(n):
+                dt = base + timedelta(minutes=i)
+                c = 22500 + i
+                f.write(f"{dt.strftime('%Y/%m/%d %H:%M')},{c},{c+5},{c-5},{c},10\n")
+
+    def test_progress_cb_called_and_order_preserved(self, tmp_path):
+        strategy = OneMinRecordingStrategy()  # 1-min native → heavy rebuild path
+        runner = LiveRunner(strategy, "TX00", log_dir=str(tmp_path))
+
+        n = 1300  # > 2 * _RELOAD_PROGRESS_EVERY (500)
+        csv_path = os.path.join(runner.bot_dir, "bars_1m_20260228.csv")
+        self._write_many_bars(csv_path, n)
+
+        calls: list[tuple[int, int]] = []
+        count = runner.reload_1m_bars(progress_cb=lambda d, t: calls.append((d, t)))
+
+        assert count == n
+        # Progress fired at least once per heavy loop.
+        assert len(calls) >= 2
+        # Every tick reports a positive batch count (multiple of the stride).
+        assert all(d > 0 and d % runner._RELOAD_PROGRESS_EVERY == 0
+                   for d, _ in calls)
+        # Parse phase reports total=0 (unknown); rebuild phase reports the
+        # real total once known.
+        assert any(t == 0 for _, t in calls)      # parse phase
+        assert any(t == n for _, t in calls)      # rebuild phase, total known
+        # Bars are still in chronological order (callback only observes).
+        agg = runner.get_bars()
+        assert [b.dt for b in agg] == sorted(b.dt for b in agg)
+        assert len(agg) == n
+
+    def test_no_callback_is_safe(self, tmp_path):
+        """Omitting progress_cb (default None) must not raise."""
+        strategy = OneMinRecordingStrategy()
+        runner = LiveRunner(strategy, "TX00", log_dir=str(tmp_path))
+        csv_path = os.path.join(runner.bot_dir, "bars_1m_20260228.csv")
+        self._write_many_bars(csv_path, 600)
+        assert runner.reload_1m_bars() == 600
+
+    def test_broken_callback_does_not_break_reload(self, tmp_path):
+        """A raising progress_cb must be swallowed — reload still completes."""
+        strategy = OneMinRecordingStrategy()
+        runner = LiveRunner(strategy, "TX00", log_dir=str(tmp_path))
+        csv_path = os.path.join(runner.bot_dir, "bars_1m_20260228.csv")
+        self._write_many_bars(csv_path, 600)
+
+        def _boom(done, total):
+            raise RuntimeError("UI callback blew up")
+
+        assert runner.reload_1m_bars(progress_cb=_boom) == 600
 
 
 # ── Regression: issue #45 — real_entry_price flow into Trades ──

--- a/tests/test_trade_source_and_hotswap.py
+++ b/tests/test_trade_source_and_hotswap.py
@@ -210,6 +210,34 @@ class TestCheckModeOverride:
             f.write("not json{{{")
         assert runner._check_mode_override() is None
 
+    def test_skips_override_while_reloading(self, tmp_path):
+        """Issue #79: during warmup/history replay (_is_reloading=True) a
+        pending mode_override.json must NOT be consumed — it would race with
+        the resume UI sync and blank the mode tag."""
+        runner = LiveRunner(NeverTradeStrategy(), "TX00", log_dir=str(tmp_path))
+        override_path = os.path.join(runner.bot_dir, "mode_override.json")
+        os.makedirs(os.path.dirname(override_path), exist_ok=True)
+        with open(override_path, "w") as f:
+            json.dump({"trading_mode": "auto"}, f)
+
+        runner._is_reloading = True
+        assert runner._check_mode_override() is None
+        # File must be preserved (not consumed) so it applies once live.
+        assert os.path.exists(override_path)
+
+        # Once reloading is done, the override applies normally.
+        runner._is_reloading = False
+        assert runner._check_mode_override() == "auto"
+        assert not os.path.exists(override_path)
+
+    def test_feed_warmup_sets_reloading_flag(self, tmp_path):
+        """feed_warmup_bars marks the reloading window so mode overrides are
+        ignored until the GUI clears the flag on the first live tick."""
+        runner = LiveRunner(NeverTradeStrategy(), "TX00", log_dir=str(tmp_path))
+        assert runner._is_reloading is False
+        runner.feed_warmup_bars([])
+        assert runner._is_reloading is True
+
 
 class TestApplyModeSwitch:
     def _make_runner(self, tmp_path, mode="paper", allow_override=False):

--- a/tests/test_trading_safety.py
+++ b/tests/test_trading_safety.py
@@ -456,6 +456,88 @@ class TestFillPendingBlocks:
         assert verdict == g.SEND_EXIT  # NOT blocked
 
 
+class TestScenarioIssue79ResumeReconcile:
+    """Issue #79: on session resume the bot inherits an open position from a
+    previous run. guard.reset() (called on every deploy) clears
+    real_entry_confirmed and fill_pending, so the restored position looks
+    like "no real entry" and every exit/force-close gets SKIP_EXIT'd — the
+    live position is stuck open until the user manually switches modes.
+
+    restore_confirmed_position() reconciles the guard so exits fire again.
+    """
+
+    def test_known_bad_force_close_skipped_without_reconcile(self):
+        """Documents the bug: without reconcile, a restored position with a
+        stale fill_pending cannot be force-closed."""
+        g = TradingGuard()
+        g.reset()                 # simulates deploy-time reset
+        g.fill_pending = True     # stale entry-fill flag from crashed session
+        g.fill_pending_type = "entry"
+        # real_entry_confirmed is False after reset — FORCE_CLOSE reaches
+        # check_exit and is skipped even though a real position exists.
+        verdict, _ = g.decide("semi_auto", "FORCE_CLOSE", "LONG")
+        assert verdict == g.SKIP_EXIT
+
+    def test_reconcile_clears_stale_fill_pending(self):
+        g = TradingGuard()
+        g.reset()
+        g.fill_pending = True
+        g.fill_pending_type = "entry"
+        cleared = g.restore_confirmed_position()
+        assert cleared is True
+        assert g.fill_pending is False
+        assert g.fill_pending_type == ""
+        assert g.real_entry_confirmed is True
+
+    def test_reconcile_reports_no_stale_pending(self):
+        g = TradingGuard()
+        g.reset()  # fill_pending already False
+        cleared = g.restore_confirmed_position()
+        assert cleared is False
+        assert g.real_entry_confirmed is True
+
+    def test_force_close_fires_after_reconcile(self):
+        """The core regression: position_size>0 + fill_pending=True on resume
+        → force-close must fire (SEND_EXIT) after reconciliation."""
+        g = TradingGuard()
+        g.reset()
+        g.fill_pending = True
+        g.fill_pending_type = "entry"
+        g.restore_confirmed_position()
+        verdict, details = g.decide("semi_auto", "FORCE_CLOSE", "LONG")
+        assert verdict == g.SEND_EXIT
+        assert details["new_close"] == 1  # explicit close
+
+    def test_normal_trade_close_fires_after_reconcile(self):
+        """A strategy-driven TRADE_CLOSE (the red-box case) must also fire."""
+        g = TradingGuard()
+        g.reset()
+        g.fill_pending = True
+        g.fill_pending_type = "entry"
+        g.restore_confirmed_position()
+        verdict, _ = g.decide("semi_auto", "TRADE_CLOSE", "LONG")
+        assert verdict == g.SEND_EXIT
+
+    def test_reconcile_discards_deferred_close(self):
+        """A deferred close waiting on a fill that will never come is dropped —
+        the reconciled exit will be re-issued by the strategy instead."""
+        g = TradingGuard()
+        g.reset()
+        g.fill_pending = True
+        g.defer_close({"action": "TRADE_CLOSE", "side": "LONG"})
+        g.restore_confirmed_position()
+        assert g.pop_deferred_close() is None
+
+    def test_auto_mode_force_close_fires_after_reconcile(self):
+        g = TradingGuard()
+        g.reset()
+        g.fill_pending = True
+        g.fill_pending_type = "entry"
+        g.restore_confirmed_position()
+        verdict, _ = g.decide("auto", "FORCE_CLOSE", "SHORT")
+        assert verdict == g.SEND_EXIT
+
+
 class TestFillConfirmedResumes:
     """After on_fill_confirmed(), orders should flow normally again."""
 


### PR DESCRIPTION
Fixes #79.

Three bugs that surface when a live bot **resumes a session with an open position** after a server crash / restart (reported: `AI: BbandMonthShortV5` on `TMF00`, semi_auto, position +1).

## B (CRITICAL) — force-close / close order never fires after resume
**Root cause:** `_deploy_live` calls `guard.reset()` on every deploy, clearing `real_entry_confirmed` **and** `fill_pending`. But `restore_session()` then loads a broker that already holds a **confirmed** position from the previous session. The COM reconnect never re-confirms that old fill, so:
- `real_entry_confirmed` stays `False` → every `TRADE_CLOSE`/`FORCE_CLOSE` is `SKIP_EXIT`'d ("no real entry was confirmed"). This is the reported red-box "平倉單沒帶入".
- any stale `fill_pending` (auto mode) → `BLOCK_FILL_PENDING` → the close is deferred forever (no entry fill will ever arrive to replay it).

**Fix:** new `TradingGuard.restore_confirmed_position()` (clears `fill_pending`, sets `real_entry_confirmed=True`, drops any dangling deferred close). Called in `_deploy_live` right after `restore_session()` when `broker.position_size > 0`, with `[RESUME]` log lines. This also makes the existing stop-time force-close path (guarded by `real_entry_confirmed`) work for resumed positions.

## A — UI freeze during bar reload after resume
`reload_1m_bars()` re-fed potentially thousands of saved 1-min bars through the data_store/HTF rebuild in one blocking main-thread call, freezing Tkinter for seconds on long-lookback strategies.

**Fix:** optional `progress_cb(done, total)` hook (LiveRunner stays UI-agnostic) fired every 500 bars across both heavy loops. The GUI callback logs `[RESUME] Reloading bars: N/M...` and pumps the event loop via `update_idletasks()` — redraw-only, deliberately **not** `update()`, to avoid a "Stop Bot" click re-entering `_stop_live()` and clearing `_live_runner` underneath the still-running reload. Bars are still fed strictly in order.

## C — trading-mode tag disappears until manual mode switch
On resume the mode tag blanked during warmup replay; `_check_mode_override()` runs on every aggregated bar (including history replay) and could apply a stale `mode_override.json`, racing the UI.

**Fix:** new `LiveRunner._is_reloading` flag (True across warmup + history replay, cleared on the history→live transition and re-armed on reconnect). `_check_mode_override()` short-circuits while set. `trading_mode_var` is explicitly re-synced after `restore_session()` with a `[RESUME] Trading mode restored: <mode>` log.

## Tests
- `test_trading_safety.py::TestScenarioIssue79ResumeReconcile` — documents the known-bad `SKIP_EXIT`, then verifies force-close **and** normal close fire after reconciliation (semi_auto + auto), stale `fill_pending` cleared, deferred close dropped.
- `test_trade_source_and_hotswap.py` — `_check_mode_override` skipped (file preserved) while `_is_reloading`, and `feed_warmup_bars` arms the flag.
- `test_live_runner.py::TestReload1mBarsProgressIssue79` — progress fires per heavy loop, bar order preserved, `None`/raising callbacks are safe.

Full suite: **1295 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
