### PR TITLE
fix(live): drop out-of-order ticks/bars after COM reconnect (#78)

### DIFF
--- a/run_backtest.py
+++ b/run_backtest.py
@@ -1074,6 +1074,13 @@ class BacktestApp:
         # Issue #79: reconnect re-enters the history-replay window — ignore
         # mode overrides until the history→live transition clears the flag.
         self._live_runner._is_reloading = True
+        # Issue #78: the replay burst can carry ticks/bars whose timestamps go
+        # backwards relative to what we already processed. Reset the
+        # out-of-order guards so the first tick/bar after the gap is accepted,
+        # then let the monotonicity checks drop the stale remainder of the burst.
+        if self._live_bar_builder is not None:
+            self._live_bar_builder.reset_stale_tracking()
+        self._live_runner.reset_bar_monotonicity()
         # Track when this RequestTicks fired so we can log latency to first tick
         # (and detect zombie subscriptions where no tick arrives).
         self._ticks_requested_at = time.time()

--- a/run_backtest.py
+++ b/run_backtest.py
@@ -1071,6 +1071,9 @@ class BacktestApp:
         self._live_history_tick_count = 0
         self._live_stale_drops = 0
         self._live_runner.suppress_strategy = True
+        # Issue #79: reconnect re-enters the history-replay window — ignore
+        # mode overrides until the history→live transition clears the flag.
+        self._live_runner._is_reloading = True
         # Track when this RequestTicks fired so we can log latency to first tick
         # (and detect zombie subscriptions where no tick arrives).
         self._ticks_requested_at = time.time()
@@ -4851,6 +4854,35 @@ class BacktestApp:
             n = self._live_runner.restore_session(resume_session)
             self._live_log_msg(f"恢復交易紀錄 Resumed session: {n} trades restored", "status")
 
+            # Issue #79: reconcile the safety guard with the restored position.
+            # guard.reset() (line above at deploy) cleared real_entry_confirmed
+            # and fill_pending, but the restored broker may already hold an
+            # open position from the previous session. Without this, every
+            # exit/force-close is SKIP_EXIT'd (real_entry_confirmed=False) and
+            # any stale fill_pending would BLOCK_FILL_PENDING the close forever
+            # — the live position stays stuck open until the user manually
+            # switches trading modes.
+            if self._live_runner.broker.position_size > 0:
+                cleared = self._trading_guard.restore_confirmed_position()
+                if cleared:
+                    self._live_log_msg(
+                        "[RESUME] Cleared stale fill_pending — position already "
+                        "confirmed from previous session", "status")
+                self._live_log_msg(
+                    "[RESUME] Restored confirmed real position — exits/"
+                    "force-close re-enabled", "status")
+
+            # Issue #79 (sub-problem C): explicitly re-sync the mode tag now,
+            # before warmup/replay begins. The var was set at deploy time, but
+            # re-asserting it here (and guarding _check_mode_override while
+            # _is_reloading) keeps the tag from momentarily blanking during
+            # history replay until a manual mode switch restores it.
+            combo_label = self._mode_key_to_combo.get(
+                self._trading_mode, self._trading_mode)
+            self.trading_mode_var.set(combo_label)
+            self._live_log_msg(
+                f"[RESUME] Trading mode restored: {self._trading_mode}", "status")
+
         # Register callbacks
         self._live_runner.on("on_bar", lambda b: self.root.after(0, self._on_live_bar, b))
         self._live_runner.on("on_decision", lambda d: self.root.after(0, self._on_live_decision, d))
@@ -5027,6 +5059,28 @@ class BacktestApp:
                  f"[{type(e).__name__}] {e}")
         self._start_live_tick_subscription()
 
+    def _on_reload_progress(self, done: int, total: int) -> None:
+        """Progress hook for LiveRunner.reload_1m_bars (issue #79).
+
+        Logs every batch and pumps the Tk event loop so the window stays
+        painted during a long bar reload. Uses update_idletasks() (redraw
+        only) rather than update() on purpose: a full update() would
+        dispatch queued user input — a "Stop Bot" click mid-reload would
+        re-enter _stop_live() and clear self._live_runner underneath the
+        still-running reload, crashing on return. update_idletasks() keeps
+        the UI responsive-looking without that re-entrancy hazard.
+        """
+        if total:
+            self._live_log_msg(
+                f"[RESUME] Reloading bars: {done}/{total}...", "status")
+        else:
+            self._live_log_msg(
+                f"[RESUME] Reloading bars: {done}...", "status")
+        try:
+            self.root.update_idletasks()
+        except Exception:
+            pass  # window may be tearing down — never break the reload
+
     # ── Tick-based live data feed ──
 
     def _start_live_tick_subscription(self):
@@ -5034,8 +5088,14 @@ class BacktestApp:
         if not self._live_runner:
             return
 
-        # Reload saved 1-min bars from CSV (for resumed sessions)
-        n_reloaded = self._live_runner.reload_1m_bars()
+        # Reload saved 1-min bars from CSV (for resumed sessions).
+        # Issue #79: for long-lookback strategies the reload can re-feed
+        # thousands of bars through fresh HTF aggregators in one blocking
+        # call, freezing the UI for seconds. Pass a progress callback that
+        # logs every 500 bars and pumps the Tk event loop so the window
+        # stays painted/responsive during the reload.
+        n_reloaded = self._live_runner.reload_1m_bars(
+            progress_cb=self._on_reload_progress)
         if n_reloaded > 0:
             self._live_log_msg(
                 f"已載入歷史1分K Reloaded {n_reloaded} saved 1m bars from CSV", "status")
@@ -5494,6 +5554,9 @@ class BacktestApp:
             self._live_history_done = True
             self._live_history_tick_count = self._live_tick_count
             self._live_runner.suppress_strategy = False
+            # Issue #79: reloading window is over — live hot-swap mode
+            # overrides may now be honored again.
+            self._live_runner._is_reloading = False
             status = self._live_runner.get_status()
             self._live_log_msg(
                 f"歷史報價完成 History ticks done: {self._live_tick_count} ticks, "

--- a/src/live/bar_aggregator.py
+++ b/src/live/bar_aggregator.py
@@ -6,10 +6,13 @@ so bar boundaries align naturally with TAIFEX trading sessions.
 
 from __future__ import annotations
 
+import logging
 from datetime import datetime, timedelta
 
 from ..market_data.models import Bar
 from ..market_data.sessions import session_align
+
+logger = logging.getLogger(__name__)
 
 
 class BarAggregator:
@@ -29,6 +32,14 @@ class BarAggregator:
         self._current: Bar | None = None
         self._current_start: datetime | None = None
 
+        # Out-of-order bar guard (issue #78). A post-reconnect tick-history
+        # replay can emit 1-min bars whose times go backwards; track the last
+        # accepted bar time so a stale bar cannot corrupt the aggregation or
+        # spawn a spurious extra bar. This tracks the RAW incoming ``bar.dt``,
+        # NOT the session-aligned boundary, so consecutive 1-min bars within
+        # the same aggregation window are both accepted.
+        self._last_bar_time: datetime | None = None
+
     def _align_time(self, dt: datetime) -> datetime:
         """Align datetime to the target bar boundary (session-start-based)."""
         return session_align(dt, self._interval)
@@ -42,6 +53,17 @@ class BarAggregator:
         bar's arrival, leaving the chart and strategy permanently 1 bar
         behind real time (issue #44).
         """
+        # Drop out-of-order/duplicate bars from post-reconnect history replay
+        # (issue #78). Guard on the raw incoming time BEFORE the 1-min
+        # pass-through so stale bars are rejected in every timeframe.
+        if self._last_bar_time is not None and bar.dt <= self._last_bar_time:
+            logger.warning(
+                "[AGG] Dropped out-of-order bar: %s <= last %s",
+                bar.dt, self._last_bar_time,
+            )
+            return None
+        self._last_bar_time = bar.dt
+
         if self._interval == 60:
             return bar
 
@@ -81,6 +103,17 @@ class BarAggregator:
         """Clear state."""
         self._current = None
         self._current_start = None
+        self._last_bar_time = None
+
+    def reset_stale_tracking(self) -> None:
+        """Reset the out-of-order bar guard (issue #78) WITHOUT discarding the
+        in-progress aggregation window.
+
+        Call on reconnect / history-replay start so the first bar after the
+        gap is always accepted, regardless of its timestamp relative to the
+        last bar seen before the drop.
+        """
+        self._last_bar_time = None
 
     def _start(self, aligned_dt: datetime, bar: Bar) -> None:
         self._current_start = aligned_dt

--- a/src/live/live_runner.py
+++ b/src/live/live_runner.py
@@ -379,6 +379,11 @@ class LiveRunner:
         self._warmup_bar_count: int = 0  # count of warmup bars in _aggregated_bars
         self._callbacks: dict[str, list] = {}
         self.suppress_strategy: bool = False  # suppress strategy during history catchup
+        # Issue #79: True from warmup start until history replay completes.
+        # While set, _check_mode_override() is skipped so a stale
+        # mode_override.json (or a race with the resume UI sync) can't flip
+        # the trading mode mid-replay and blank the mode tag.
+        self._is_reloading: bool = False
         self.trading_mode: str = "paper"  # "paper", "semi_auto", or "auto"
         self.broker.trade_source = _mode_to_source(self.trading_mode)
         self.daily_loss_limit: int = 10000  # NTD, for session persistence
@@ -446,6 +451,12 @@ class LiveRunner:
 
     def _check_mode_override(self) -> str | None:
         """Read and consume a mode_override.json file from the bot directory."""
+        # Issue #79: never consume/apply a mode override during warmup or
+        # history replay. Applying one mid-replay races with the resume UI
+        # sync and makes the mode tag disappear until the user manually
+        # switches modes. Live hot-swaps resume once _is_reloading clears.
+        if self._is_reloading:
+            return None
         override_path = os.path.join(self.bot_dir, "mode_override.json")
         try:
             if not os.path.exists(override_path):
@@ -535,6 +546,10 @@ class LiveRunner:
     def feed_warmup_bars(self, kline_strings: list[str]) -> int:
         """Parse historical bars and seed DataStore. Returns bar count loaded."""
         self.state = LiveState.WARMING_UP
+        # Issue #79: warmup + the tick-history replay that follows are the
+        # "reloading" window. Mark it so mode overrides are ignored until
+        # the GUI clears the flag when live ticks begin.
+        self._is_reloading = True
 
         bars = parse_kline_strings(
             kline_strings, symbol=self.symbol, interval=self.target_interval,
@@ -1089,7 +1104,12 @@ class LiveRunner:
         self._started_at = session_data.get("started_at", self._started_at)
         return len(self.broker.trades)
 
-    def reload_1m_bars(self) -> int:
+    # Emit a progress tick every N bars during reload so the GUI can keep
+    # the Tkinter event loop pumping (issue #79 — long-lookback strategies
+    # froze the UI for seconds while thousands of saved bars were re-fed).
+    _RELOAD_PROGRESS_EVERY = 500
+
+    def reload_1m_bars(self, progress_cb: Callable[[int, int], None] | None = None) -> int:
         """Reload saved 1-min bar CSVs into _1m_bars and _seen_1m_dts.
 
         Call AFTER restore_session() and feed_warmup_bars().
@@ -1108,10 +1128,25 @@ class LiveRunner:
         bars but then drops them via the _seen_1m_dts dedup before they
         can reach _aggregated_bars (issue #45).
 
+        ``progress_cb`` (issue #79): optional ``(done, total) -> None`` hook
+        invoked every ``_RELOAD_PROGRESS_EVERY`` bars during the two heavy
+        loops (CSV parse and, for 1-min strategies, the data_store/HTF
+        rebuild). LiveRunner is UI-agnostic, so the GUI passes a callback
+        that logs progress and pumps the Tkinter event loop to stay
+        responsive. ``total`` is 0 while it is not yet known (parse phase).
+        Bars are still fed strictly in order — the callback only observes.
+
         Returns the number of NEW 1-min bars loaded from CSV.
         """
         import csv
         import glob as glob_mod
+
+        def _tick(done: int, total: int) -> None:
+            if progress_cb is not None:
+                try:
+                    progress_cb(done, total)
+                except Exception:
+                    pass  # a broken UI callback must never break the reload
 
         pattern = os.path.join(self.bot_dir, "bars_1m_*.csv")
         csv_files = sorted(glob_mod.glob(pattern))
@@ -1146,6 +1181,9 @@ class LiveRunner:
                             self._seen_1m_dts.add(dt)
                             self._1m_bars.append(bar)
                             new_bars.append(bar)
+                            # total unknown during parse → 0
+                            if len(new_bars) % self._RELOAD_PROGRESS_EVERY == 0:
+                                _tick(len(new_bars), 0)
                         except (ValueError, IndexError):
                             continue
             except OSError:
@@ -1170,8 +1208,11 @@ class LiveRunner:
             from ..market_data.data_store import DataStore
             maxlen = self.data_store._bars.maxlen or 5000
             new_store = DataStore(max_bars=maxlen)
-            for b in merged:
+            total = len(merged)
+            for i, b in enumerate(merged, 1):
                 new_store.add_bar(b)
+                if i % self._RELOAD_PROGRESS_EVERY == 0:
+                    _tick(i, total)
             self.data_store = new_store
             # MTF: rebuild HTF state by re-feeding primary bars through
             # fresh aggregators so backtest/live parity holds across
@@ -1183,8 +1224,10 @@ class LiveRunner:
                     iv: BarAggregator(self.symbol, iv)
                     for iv in self._htf_intervals
                 }
-                for b in merged:
+                for i, b in enumerate(merged, 1):
                     self._feed_htf(b)
+                    if i % self._RELOAD_PROGRESS_EVERY == 0:
+                        _tick(i, total)
             # CSV-loaded bars are historical, not live — bump
             # _warmup_bar_count so get_live_bars() continues to slice
             # off the correct prefix.

--- a/src/live/live_runner.py
+++ b/src/live/live_runner.py
@@ -515,6 +515,17 @@ class LiveRunner:
             except Exception:
                 pass
 
+    def reset_bar_monotonicity(self) -> None:
+        """Reset the out-of-order bar guards on all aggregators (issue #78).
+
+        Called by the GUI when a reconnect re-enters the tick-history replay
+        window, so the first bar after the gap is always accepted without
+        discarding any in-progress aggregation.
+        """
+        self.aggregator.reset_stale_tracking()
+        for agg in self._htf_aggregators.values():
+            agg.reset_stale_tracking()
+
     # ── Warmup ──
 
     def get_warmup_params(self) -> dict:

--- a/src/live/trading_guard.py
+++ b/src/live/trading_guard.py
@@ -132,6 +132,34 @@ class TradingGuard:
         self.halted = False
         self.halt_reason = ""
 
+    # ── Session resume reconciliation (issue #79) ──
+
+    def restore_confirmed_position(self) -> bool:
+        """Reconcile guard state for a position inherited from a prior session.
+
+        On session resume the bot re-adopts an open position it opened in a
+        previous run (restored via ``broker.from_dict``). That entry was
+        already confirmed last session — no fresh ``on_fill_confirmed`` will
+        arrive from the COM reconnect. Without this reconciliation the guard
+        (which was ``reset()`` on deploy) still believes no real entry exists:
+
+          * ``real_entry_confirmed`` stays False, so every exit / force-close
+            is SKIP_EXIT'd ("no real entry was confirmed") and the live
+            position is stuck open until the user manually switches modes
+            (issue #79 — the reported "平倉單沒帶入" symptom).
+          * any stale ``fill_pending`` (auto mode) would BLOCK_FILL_PENDING the
+            exit and defer it forever, because the entry fill it is waiting on
+            already happened in the previous session.
+
+        Returns True if a stale ``fill_pending`` was cleared (for logging).
+        """
+        had_pending = self.fill_pending
+        self.fill_pending = False
+        self.fill_pending_type = ""
+        self.real_entry_confirmed = True
+        self._deferred_close = None
+        return had_pending
+
     # ── Margin check ──
 
     @staticmethod

--- a/src/market_data/bar_builder.py
+++ b/src/market_data/bar_builder.py
@@ -30,6 +30,13 @@ class BarBuilder:
         self._bar_start: datetime | None = None
         self._completed_bars: list[Bar] = []
 
+        # Out-of-order tick guard (issue #78). After a COM dropout, RequestTicks
+        # replays historical ticks in a burst that can contain timestamps going
+        # backwards relative to already-processed ticks. Track the last accepted
+        # tick time and drop anything that is not strictly newer, so a stale
+        # replay tick cannot corrupt the current bar's OHLCV.
+        self._last_tick_time: datetime | None = None
+
     @property
     def completed_bars(self) -> list[Bar]:
         return self._completed_bars
@@ -47,6 +54,16 @@ class BarBuilder:
 
     def on_tick(self, tick: Tick) -> Bar | None:
         """Process a tick. Returns a completed bar if a bar boundary was crossed."""
+        # Drop stale/out-of-order ticks from post-reconnect history replay
+        # (issue #78) before they can mutate the current bar.
+        if self._last_tick_time is not None and tick.dt <= self._last_tick_time:
+            logger.warning(
+                "[BAR] Dropped stale tick: %s <= last %s",
+                tick.dt, self._last_tick_time,
+            )
+            return None
+        self._last_tick_time = tick.dt
+
         bar_time = self._align_time(tick.dt)
 
         # First tick ever
@@ -104,3 +121,12 @@ class BarBuilder:
         if self._current_bar is None:
             return None
         return self._finalize_bar()
+
+    def reset_stale_tracking(self) -> None:
+        """Reset the out-of-order tick guard (issue #78).
+
+        Call on reconnect / history-replay start so the first tick after the
+        gap is always accepted, regardless of its timestamp relative to the
+        last tick seen before the drop.
+        """
+        self._last_tick_time = None

--- a/tests/test_bar_aggregator.py
+++ b/tests/test_bar_aggregator.py
@@ -418,3 +418,86 @@ class TestBarAggregator1mPassThrough:
         partial = agg.get_partial_bar()
         assert partial is not None
         assert partial.close == 101
+
+
+# ── Regression: issue #78 — out-of-order bar guard ──
+
+class TestBarAggregatorOutOfOrderGuard:
+    """Issue #78: a post-reconnect tick-history replay can emit 1-min bars
+    whose times go backwards. Such bars must be dropped so they cannot corrupt
+    the aggregation window or spawn a spurious extra bar."""
+
+    def test_out_of_order_bar_dropped_htf(self):
+        """An older bar must not mutate the in-progress H4 window."""
+        agg = BarAggregator("TX00", 14400)
+        agg.on_bar(_bar("2026-03-02 08:45", o=100, h=110, l=90, c=105, v=10))
+        agg.on_bar(_bar("2026-03-02 09:00", o=105, h=120, l=100, c=115, v=20))
+        partial_before = agg.get_partial_bar()
+
+        # Burst replay: a bar timestamped BEFORE the last accepted bar.
+        result = agg.on_bar(_bar("2026-03-02 08:50", o=50, h=999, l=1, c=42, v=99))
+
+        assert result is None
+        partial_after = agg.get_partial_bar()
+        # Window untouched — no OHLCV corruption from the stale bar.
+        assert (partial_after.open, partial_after.high, partial_after.low,
+                partial_after.close, partial_after.volume) == (
+            partial_before.open, partial_before.high, partial_before.low,
+            partial_before.close, partial_before.volume)
+
+    def test_out_of_order_bar_dropped_passthrough(self):
+        """The guard also applies in the 1-min pass-through path."""
+        agg = BarAggregator("TX00", 60)
+        agg.on_bar(_bar("2026-03-02 09:05", c=100))
+        # Older bar in the burst — must be dropped, not passed through.
+        result = agg.on_bar(_bar("2026-03-02 09:02", c=200))
+        assert result is None
+
+    def test_duplicate_bar_dropped(self):
+        """A bar at exactly the last accepted time (<=) is dropped."""
+        agg = BarAggregator("TX00", 14400)
+        agg.on_bar(_bar("2026-03-02 09:00", o=100, h=110, l=90, c=105, v=10))
+        result = agg.on_bar(_bar("2026-03-02 09:00", o=100, h=999, l=1, c=42, v=99))
+        assert result is None
+        partial = agg.get_partial_bar()
+        assert partial.high == 110  # unchanged
+        assert partial.volume == 10
+
+    def test_consecutive_1m_bars_in_window_both_accepted(self):
+        """Guard must NOT reject distinct 1-min bars in the same HTF window
+        (it tracks raw bar.dt, not the aligned boundary)."""
+        agg = BarAggregator("TX00", 14400)
+        assert agg.on_bar(_bar("2026-03-02 08:45", v=1)) is None
+        assert agg.on_bar(_bar("2026-03-02 08:46", v=1)) is None
+        assert agg.on_bar(_bar("2026-03-02 08:47", v=1)) is None
+        partial = agg.get_partial_bar()
+        assert partial.volume == 3  # all three accepted
+
+    def test_reset_stale_tracking_accepts_next_bar(self):
+        """After reset_stale_tracking(), the next bar is accepted regardless of
+        its timestamp — without discarding the in-progress window."""
+        agg = BarAggregator("TX00", 14400)
+        agg.on_bar(_bar("2026-03-02 09:00", o=100, h=110, l=90, c=105, v=10))
+
+        # Reconnect: replay restarts from an earlier checkpoint.
+        agg.reset_stale_tracking()
+
+        # In-progress window survived the reset.
+        assert agg.get_partial_bar() is not None
+        # An "older" bar is now accepted and folds into the window.
+        result = agg.on_bar(_bar("2026-03-02 08:50", o=105, h=120, l=80, c=108, v=5))
+        assert result is None  # same 08:45 H4 window
+        partial = agg.get_partial_bar()
+        assert partial.high == 120  # updated by the accepted bar
+        assert partial.volume == 15
+
+    def test_full_reset_clears_tracker(self):
+        """reset() clears the monotonicity tracker too, so a fresh stream of
+        any timestamp is accepted."""
+        agg = BarAggregator("TX00", 60)
+        agg.on_bar(_bar("2026-03-02 09:05", c=100))
+        agg.reset()
+        # A bar older than the pre-reset one is accepted after a full reset.
+        result = agg.on_bar(_bar("2026-03-02 09:02", c=200))
+        assert result is not None
+        assert result.close == 200

--- a/tests/test_bar_builder.py
+++ b/tests/test_bar_builder.py
@@ -88,3 +88,67 @@ class TestBarBuilder:
         event_bus.drain()
         assert len(received) == 1
         assert received[0].open == 20000
+
+
+class TestOutOfOrderTickGuard:
+    """Issue #78: drop stale/out-of-order ticks from post-reconnect replay."""
+
+    def test_stale_tick_is_dropped(self):
+        """A tick older than the last accepted tick must not mutate the bar."""
+        bb = BarBuilder("TXFD0", 60)
+        bb.on_tick(_tick(20000, 1, 0, minute=0))
+        bb.on_tick(_tick(20050, 2, 30, minute=0))
+
+        snapshot = (bb.current_bar.open, bb.current_bar.high,
+                    bb.current_bar.low, bb.current_bar.close,
+                    bb.current_bar.volume)
+
+        # Burst replay: a tick with a timestamp that goes backwards.
+        result = bb.on_tick(_tick(19000, 99, 10, minute=0))
+
+        assert result is None
+        assert (bb.current_bar.open, bb.current_bar.high,
+                bb.current_bar.low, bb.current_bar.close,
+                bb.current_bar.volume) == snapshot
+
+    def test_duplicate_tick_is_dropped(self):
+        """A tick at exactly the last timestamp (<=) is also dropped."""
+        bb = BarBuilder("TXFD0", 60)
+        bb.on_tick(_tick(20000, 1, 30, minute=0))
+        vol_before = bb.current_bar.volume
+
+        # Same timestamp, different price/qty — treated as a duplicate.
+        result = bb.on_tick(_tick(20100, 5, 30, minute=0))
+
+        assert result is None
+        assert bb.current_bar.volume == vol_before
+        assert bb.current_bar.close == 20000  # unchanged
+
+    def test_stale_tick_does_not_spawn_new_bar(self):
+        """A stale tick in a later minute must not create a spurious bar."""
+        bb = BarBuilder("TXFD0", 60)
+        bb.on_tick(_tick(20000, 1, 0, minute=5))  # last = 09:05:00
+        # Older tick that aligns to an earlier minute — would wrongly finalize
+        # and start a new bar without the guard.
+        result = bb.on_tick(_tick(19900, 1, 0, minute=2))
+
+        assert result is None
+        assert len(bb.completed_bars) == 0
+        assert bb.current_bar.dt.minute == 5
+
+    def test_reset_accepts_first_tick_regardless(self):
+        """After reset_stale_tracking(), the next tick is always accepted."""
+        bb = BarBuilder("TXFD0", 60)
+        bb.on_tick(_tick(20000, 1, 30, minute=10))  # last = 09:10:30
+
+        # Reconnect: replay restarts from an earlier checkpoint.
+        bb.reset_stale_tracking()
+
+        result = bb.on_tick(_tick(19950, 3, 0, minute=2))  # older timestamp
+        # New bar started fresh from the "older" replayed tick.
+        assert bb.current_bar is not None
+        assert bb.current_bar.dt.minute == 2
+        assert bb.current_bar.open == 19950
+        # Finalized the minute-10 bar on the boundary cross.
+        assert result is not None
+        assert result.dt.minute == 10

--- a/tests/test_live_runner.py
+++ b/tests/test_live_runner.py
@@ -1,7 +1,7 @@
 """Tests for LiveRunner: warmup, feed, dedup, strategy execution, stop."""
 
 import os
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from src.market_data.models import Bar
 from src.market_data.data_store import DataStore
@@ -1085,6 +1085,69 @@ class TestReload1mBarsIssue45:
         runner.reload_1m_bars()
 
         assert runner.data_store._bars.maxlen == original_maxlen
+
+
+# ── Regression: issue #79 — reload progress yields (UI freeze) ──
+
+class TestReload1mBarsProgressIssue79:
+    """reload_1m_bars must report progress so the GUI can pump the Tk event
+    loop and stay responsive while re-feeding thousands of saved bars."""
+
+    @staticmethod
+    def _write_many_bars(path: str, n: int) -> None:
+        base = datetime(2026, 2, 28, 0, 0)
+        with open(path, "w", encoding="utf-8") as f:
+            f.write("datetime,open,high,low,close,volume\n")
+            for i in range(n):
+                dt = base + timedelta(minutes=i)
+                c = 22500 + i
+                f.write(f"{dt.strftime('%Y/%m/%d %H:%M')},{c},{c+5},{c-5},{c},10\n")
+
+    def test_progress_cb_called_and_order_preserved(self, tmp_path):
+        strategy = OneMinRecordingStrategy()  # 1-min native → heavy rebuild path
+        runner = LiveRunner(strategy, "TX00", log_dir=str(tmp_path))
+
+        n = 1300  # > 2 * _RELOAD_PROGRESS_EVERY (500)
+        csv_path = os.path.join(runner.bot_dir, "bars_1m_20260228.csv")
+        self._write_many_bars(csv_path, n)
+
+        calls: list[tuple[int, int]] = []
+        count = runner.reload_1m_bars(progress_cb=lambda d, t: calls.append((d, t)))
+
+        assert count == n
+        # Progress fired at least once per heavy loop.
+        assert len(calls) >= 2
+        # Every tick reports a positive batch count (multiple of the stride).
+        assert all(d > 0 and d % runner._RELOAD_PROGRESS_EVERY == 0
+                   for d, _ in calls)
+        # Parse phase reports total=0 (unknown); rebuild phase reports the
+        # real total once known.
+        assert any(t == 0 for _, t in calls)      # parse phase
+        assert any(t == n for _, t in calls)      # rebuild phase, total known
+        # Bars are still in chronological order (callback only observes).
+        agg = runner.get_bars()
+        assert [b.dt for b in agg] == sorted(b.dt for b in agg)
+        assert len(agg) == n
+
+    def test_no_callback_is_safe(self, tmp_path):
+        """Omitting progress_cb (default None) must not raise."""
+        strategy = OneMinRecordingStrategy()
+        runner = LiveRunner(strategy, "TX00", log_dir=str(tmp_path))
+        csv_path = os.path.join(runner.bot_dir, "bars_1m_20260228.csv")
+        self._write_many_bars(csv_path, 600)
+        assert runner.reload_1m_bars() == 600
+
+    def test_broken_callback_does_not_break_reload(self, tmp_path):
+        """A raising progress_cb must be swallowed — reload still completes."""
+        strategy = OneMinRecordingStrategy()
+        runner = LiveRunner(strategy, "TX00", log_dir=str(tmp_path))
+        csv_path = os.path.join(runner.bot_dir, "bars_1m_20260228.csv")
+        self._write_many_bars(csv_path, 600)
+
+        def _boom(done, total):
+            raise RuntimeError("UI callback blew up")
+
+        assert runner.reload_1m_bars(progress_cb=_boom) == 600
 
 
 # ── Regression: issue #45 — real_entry_price flow into Trades ──

--- a/tests/test_live_runner.py
+++ b/tests/test_live_runner.py
@@ -8,7 +8,7 @@ from src.market_data.data_store import DataStore
 from src.backtest.broker import SimulatedBroker, BrokerContext, OrderSide
 from src.backtest.strategy import BacktestStrategy
 from src.live.live_runner import LiveRunner, LiveState, is_market_open
-from src.live.bar_aggregator import aggregate_bars
+from src.live.bar_aggregator import BarAggregator, aggregate_bars
 
 
 # ── Simple test strategy ──
@@ -1300,3 +1300,29 @@ class TestLoad1mBarsFromCsvs:
             encoding="utf-8")
         bars = load_1m_bars_from_csvs(str(tmp_path), "TX00")
         assert len(bars) == 1
+
+
+class TestResetBarMonotonicity:
+    """Issue #78: reconnect must reset the out-of-order bar guards on the
+    primary aggregator AND all HTF aggregators, so the first bar after the
+    replay gap is always accepted."""
+
+    def test_reset_clears_primary_and_htf_trackers(self, tmp_path):
+        strategy = AlwaysLongStrategy()  # 15-min primary
+        runner = LiveRunner(strategy, "TX00", point_value=200,
+                            log_dir=str(tmp_path))
+        # Force an HTF aggregator to exist alongside the primary one.
+        runner._htf_aggregators[14400] = BarAggregator("TX00", 14400)
+
+        # Advance the guards past a known time on every aggregator.
+        seed = Bar(symbol="TX00", dt=datetime(2026, 3, 2, 9, 0), open=100,
+                   high=110, low=90, close=105, volume=10, interval=60)
+        runner.aggregator.on_bar(seed)
+        runner._htf_aggregators[14400].on_bar(seed)
+        assert runner.aggregator._last_bar_time is not None
+        assert runner._htf_aggregators[14400]._last_bar_time is not None
+
+        runner.reset_bar_monotonicity()
+
+        assert runner.aggregator._last_bar_time is None
+        assert runner._htf_aggregators[14400]._last_bar_time is None

--- a/tests/test_reconnect_regression.py
+++ b/tests/test_reconnect_regression.py
@@ -258,3 +258,38 @@ class TestStructuredLoggingTags:
         assert "def _set_quote_connected(" in rb_source, (
             "Missing _set_quote_connected helper — direct assignment of "
             "self._quote_connected loses the state-transition log line.")
+
+
+# ---------------------------------------------------------------------------
+# Issue #78 — bar/tick monotonicity guard reset on reconnect
+# ---------------------------------------------------------------------------
+
+class TestIssue78_MonotonicityResetOnReconnect:
+    """After a COM dropout, RequestTicks replays history in a burst whose
+    timestamps can go backwards. `_resubscribe_ticks` must reset the
+    out-of-order guards so the first tick/bar after the gap is accepted,
+    then let the guards drop the stale remainder."""
+
+    def test_resubscribe_resets_bar_builder_guard(self, rb_source: str):
+        match = re.search(
+            r"def _resubscribe_ticks\(self.*?(?=\n    def )",
+            rb_source,
+            re.DOTALL,
+        )
+        assert match, "could not locate _resubscribe_ticks body"
+        body = match.group(0)
+        assert "reset_stale_tracking" in body, (
+            "Issue #78 regression: _resubscribe_ticks must reset the "
+            "BarBuilder out-of-order tick guard on reconnect.")
+
+    def test_resubscribe_resets_aggregator_guards(self, rb_source: str):
+        match = re.search(
+            r"def _resubscribe_ticks\(self.*?(?=\n    def )",
+            rb_source,
+            re.DOTALL,
+        )
+        assert match, "could not locate _resubscribe_ticks body"
+        body = match.group(0)
+        assert "reset_bar_monotonicity" in body, (
+            "Issue #78 regression: _resubscribe_ticks must reset the "
+            "aggregator out-of-order bar guards on reconnect.")

--- a/tests/test_trade_source_and_hotswap.py
+++ b/tests/test_trade_source_and_hotswap.py
@@ -210,6 +210,34 @@ class TestCheckModeOverride:
             f.write("not json{{{")
         assert runner._check_mode_override() is None
 
+    def test_skips_override_while_reloading(self, tmp_path):
+        """Issue #79: during warmup/history replay (_is_reloading=True) a
+        pending mode_override.json must NOT be consumed — it would race with
+        the resume UI sync and blank the mode tag."""
+        runner = LiveRunner(NeverTradeStrategy(), "TX00", log_dir=str(tmp_path))
+        override_path = os.path.join(runner.bot_dir, "mode_override.json")
+        os.makedirs(os.path.dirname(override_path), exist_ok=True)
+        with open(override_path, "w") as f:
+            json.dump({"trading_mode": "auto"}, f)
+
+        runner._is_reloading = True
+        assert runner._check_mode_override() is None
+        # File must be preserved (not consumed) so it applies once live.
+        assert os.path.exists(override_path)
+
+        # Once reloading is done, the override applies normally.
+        runner._is_reloading = False
+        assert runner._check_mode_override() == "auto"
+        assert not os.path.exists(override_path)
+
+    def test_feed_warmup_sets_reloading_flag(self, tmp_path):
+        """feed_warmup_bars marks the reloading window so mode overrides are
+        ignored until the GUI clears the flag on the first live tick."""
+        runner = LiveRunner(NeverTradeStrategy(), "TX00", log_dir=str(tmp_path))
+        assert runner._is_reloading is False
+        runner.feed_warmup_bars([])
+        assert runner._is_reloading is True
+
 
 class TestApplyModeSwitch:
     def _make_runner(self, tmp_path, mode="paper", allow_override=False):

--- a/tests/test_trading_safety.py
+++ b/tests/test_trading_safety.py
@@ -456,6 +456,88 @@ class TestFillPendingBlocks:
         assert verdict == g.SEND_EXIT  # NOT blocked
 
 
+class TestScenarioIssue79ResumeReconcile:
+    """Issue #79: on session resume the bot inherits an open position from a
+    previous run. guard.reset() (called on every deploy) clears
+    real_entry_confirmed and fill_pending, so the restored position looks
+    like "no real entry" and every exit/force-close gets SKIP_EXIT'd — the
+    live position is stuck open until the user manually switches modes.
+
+    restore_confirmed_position() reconciles the guard so exits fire again.
+    """
+
+    def test_known_bad_force_close_skipped_without_reconcile(self):
+        """Documents the bug: without reconcile, a restored position with a
+        stale fill_pending cannot be force-closed."""
+        g = TradingGuard()
+        g.reset()                 # simulates deploy-time reset
+        g.fill_pending = True     # stale entry-fill flag from crashed session
+        g.fill_pending_type = "entry"
+        # real_entry_confirmed is False after reset — FORCE_CLOSE reaches
+        # check_exit and is skipped even though a real position exists.
+        verdict, _ = g.decide("semi_auto", "FORCE_CLOSE", "LONG")
+        assert verdict == g.SKIP_EXIT
+
+    def test_reconcile_clears_stale_fill_pending(self):
+        g = TradingGuard()
+        g.reset()
+        g.fill_pending = True
+        g.fill_pending_type = "entry"
+        cleared = g.restore_confirmed_position()
+        assert cleared is True
+        assert g.fill_pending is False
+        assert g.fill_pending_type == ""
+        assert g.real_entry_confirmed is True
+
+    def test_reconcile_reports_no_stale_pending(self):
+        g = TradingGuard()
+        g.reset()  # fill_pending already False
+        cleared = g.restore_confirmed_position()
+        assert cleared is False
+        assert g.real_entry_confirmed is True
+
+    def test_force_close_fires_after_reconcile(self):
+        """The core regression: position_size>0 + fill_pending=True on resume
+        → force-close must fire (SEND_EXIT) after reconciliation."""
+        g = TradingGuard()
+        g.reset()
+        g.fill_pending = True
+        g.fill_pending_type = "entry"
+        g.restore_confirmed_position()
+        verdict, details = g.decide("semi_auto", "FORCE_CLOSE", "LONG")
+        assert verdict == g.SEND_EXIT
+        assert details["new_close"] == 1  # explicit close
+
+    def test_normal_trade_close_fires_after_reconcile(self):
+        """A strategy-driven TRADE_CLOSE (the red-box case) must also fire."""
+        g = TradingGuard()
+        g.reset()
+        g.fill_pending = True
+        g.fill_pending_type = "entry"
+        g.restore_confirmed_position()
+        verdict, _ = g.decide("semi_auto", "TRADE_CLOSE", "LONG")
+        assert verdict == g.SEND_EXIT
+
+    def test_reconcile_discards_deferred_close(self):
+        """A deferred close waiting on a fill that will never come is dropped —
+        the reconciled exit will be re-issued by the strategy instead."""
+        g = TradingGuard()
+        g.reset()
+        g.fill_pending = True
+        g.defer_close({"action": "TRADE_CLOSE", "side": "LONG"})
+        g.restore_confirmed_position()
+        assert g.pop_deferred_close() is None
+
+    def test_auto_mode_force_close_fires_after_reconcile(self):
+        g = TradingGuard()
+        g.reset()
+        g.fill_pending = True
+        g.fill_pending_type = "entry"
+        g.restore_confirmed_position()
+        verdict, _ = g.decide("auto", "FORCE_CLOSE", "SHORT")
+        assert verdict == g.SEND_EXIT
+
+
 class TestFillConfirmedResumes:
     """After on_fill_confirmed(), orders should flow normally again."""
 


### PR DESCRIPTION
Fixes #78.

## Problem
After a COM dropout, `RequestTicks` replays historical ticks in a burst. Because the replay resumes from a checkpoint (not the exact last-received tick), the burst can contain timestamps that go **backwards** relative to already-processed data. Neither `BarBuilder` (ticks → 1-min bars) nor `BarAggregator` (1-min → N-min bars) had any out-of-order detection, so a stale/duplicate tick or bar could:

- corrupt the current bar's OHLCV, or
- spawn a spurious extra aggregated bar.

This is the "聚合時間錯位 / 時鐘快轉 (clock fast-forward)" symptom the reporter saw at `11:54:37`, where a burst delivered `11:37`, then `11:52`, `11:53`, plus an aggregated `11:30` bar, all in the same instant after a ~15-minute gap.

## Fix
- **`BarBuilder.on_tick`** — track `_last_tick_time`; drop any tick whose `dt <= last` (warns `[BAR] Dropped stale tick: ...`).
- **`BarAggregator.on_bar`** — track `_last_bar_time` on the **raw** incoming `bar.dt` (not the session-aligned boundary, so two 1-min bars in the same aggregation window are both kept); drop out-of-order bars (warns `[AGG] Dropped out-of-order bar: ...`). The guard runs before the 1-min pass-through as well.
- **Reset on reconnect** — `_resubscribe_ticks` now calls `BarBuilder.reset_stale_tracking()` and `LiveRunner.reset_bar_monotonicity()` (resets the primary + all HTF aggregators **without** discarding any in-progress window), so the first tick/bar after the replay gap is always accepted; the guards then drop only the stale remainder of the burst.

## Tests
Added regression tests (`tests/test_bar_builder.py`, `tests/test_bar_aggregator.py`, `tests/test_live_runner.py`, `tests/test_reconnect_regression.py`):

- stale / duplicate tick dropped without mutating the current bar
- out-of-order bar dropped (HTF and 1-min pass-through), no OHLCV corruption
- consecutive in-window 1-min bars are **not** wrongly dropped
- after reset, an older first tick/bar is accepted, in-progress window preserved
- source pins that `_resubscribe_ticks` wires up both resets

Full suite: **1308 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)