### PR TITLE
feat(regime): trade attribution — mixed-TF aggregator rebuild, regime-aware reporting & Discord

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,7 +102,7 @@ python test_kline.py       # COM-based KLine history GUI
 - `in_closed_gap(now)`: True during gaps between sessions (when swaps can be applied)
 - `swap_strategy(new_strategy, display_name)`: 5 safety gates (flat, no veto, not in replay, same timeframe, sufficient bars)
 - `regime_idle`: separate from `suppress_strategy` — suppresses trading but keeps DataStore/CSV flowing
-- On-disk dedup: `state.last_assessed = "open_date|NIGHT"` prevents double-classification across restarts. Upgrade note: bots deployed pre-v2.16 stored the CLOSE date, so one night may be skipped once right after upgrading — clear `last_assessed` in regime_state.json to avoid it
+- On-disk dedup: `state.last_assessed = "open_date|NIGHT"` prevents double-classification across restarts. Pre-v2.16 files stored the CLOSE date; `load_state` auto-migrates it once (translates to the covered night's open-date key, gated by the `key_format` marker `save_state` stamps) — no manual edit, no skipped night, no duplicate assessment
 - `record_session_result()`: writes P&L from switching runner's own broker (replaces retired `backfill_pnl`)
 - History v2 schema: 4 new columns (strategy_active, applied, applied_at, trading_mode)
 - Deploy: `_deploy_live` branches on `regime.enabled` to construct `RegimeSwitchingRunner` vs `LiveRunner`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,11 +90,19 @@ python test_kline.py       # COM-based KLine history GUI
 
 ## Regime Switching (Phase 3)
 - `RegimeSwitchingRunner(LiveRunner)`: bot type 2, classifies regime per NIGHT session, swaps long/short strategies at session boundaries
-- `session_slot(now)`: pure function → (YYYY-MM-DD, "DAY"|"NIGHT"), DAY=08:45-13:46
+- **Session identity = OPEN date** (`current_session`/`latest_night_session` in switch_logic): the midnight-straddling night keeps ONE key ("2026-07-09|NIGHT" for the night opening 07-09 15:00). All regime keys, history rows, and P&L windows use it. `session_slot(now)` (calendar-date at poll time) survives ONLY for the daily-report key — do NOT use it for session identity.
+- `current_session` returns None on gaps/weekends/TAIFEX holidays → no phantom rows/classifications on closed days (a Sat 13:43 poll once wrote a "2026-07-11,DAY" row)
+- `classification_due`: fires in the night's last 2 min OR any time after close while unassessed (catch-up after app sleep/hang, and lets a fresh deploy classify immediately); 30-min backoff when bars are insufficient
+- Poll order is classify → record → apply: `record_session_result` UPDATES the row for (date,session) in place (idempotent re-record; stop()/restart can't double-count), so the classification row carries its own P&L
+- `_compute_session_pnl` matches trade exits inside the session's [open_dt, close_dt] window — never by calendar date (date-matching lost pre-midnight night P&L and double-counted post-midnight into DAY)
+- `stop()` records AFTER `super().stop()` so the force-close trade is included in the session row
+- Classifier bars come from `_classifier_bars` (default provider): in-memory `_aggregated_bars` (pre-seeded by the warmup KLine fetch → classifies from night one) vs CSV 1-min history, whichever aggregates to more classify-interval bars. Bound method — never capture the list object (`_rebuild_timeframe` rebinds it, issue #43 family)
+- Stale pending recommendations (older than the last completed night) are discarded, not applied; unknown-strategy applies are discarded instead of retried every 30s forever
+- Flip-counter pause uses a true sliding window (`flip_sessions`); `adx_strong` fast-track is disabled when `adx_strong <= adx_enter` (raising adx_enter must not silently reduce confirm_sessions to 1)
 - `in_closed_gap(now)`: True during gaps between sessions (when swaps can be applied)
 - `swap_strategy(new_strategy, display_name)`: 5 safety gates (flat, no veto, not in replay, same timeframe, sufficient bars)
 - `regime_idle`: separate from `suppress_strategy` — suppresses trading but keeps DataStore/CSV flowing
-- On-disk dedup: `state.last_assessed = "date|NIGHT"` prevents double-classification across restarts
+- On-disk dedup: `state.last_assessed = "open_date|NIGHT"` prevents double-classification across restarts. Upgrade note: bots deployed pre-v2.16 stored the CLOSE date, so one night may be skipped once right after upgrading — clear `last_assessed` in regime_state.json to avoid it
 - `record_session_result()`: writes P&L from switching runner's own broker (replaces retired `backfill_pnl`)
 - History v2 schema: 4 new columns (strategy_active, applied, applied_at, trading_mode)
 - Deploy: `_deploy_live` branches on `regime.enabled` to construct `RegimeSwitchingRunner` vs `LiveRunner`

--- a/run_backtest.py
+++ b/run_backtest.py
@@ -3413,11 +3413,15 @@ class BacktestApp:
             "short": "做空 Short",
             "idle": "閒置 Idle",
         }.get(leg, leg)
+        # When idle, the loaded strategy object is only the timeframe
+        # donor (its on_bar is never called) — showing its name reads as
+        # "Idle (DynamicExitPullbackStrategyV2)", which looks like it's
+        # trading. Show a dash instead.
         return {
             "long": runner.long_strategy_name,
             "short": runner.short_strategy_name,
             "active_label": leg_label,
-            "active_strategy": runner.strategy.name,
+            "active_strategy": runner.strategy.name if leg != "idle" else "—",
         }
 
     def _append_regime_log(self, max_rows: int = 8) -> None:

--- a/src/live/regime_switching_runner.py
+++ b/src/live/regime_switching_runner.py
@@ -13,9 +13,15 @@ from typing import Callable
 
 from ..regime.manager import RegimeManager
 from ..regime.state_machine import RegimeConfig
-from ..regime.switch_logic import session_slot, in_closed_gap, should_classify
-from ..regime.store import record_session_result
-from .live_runner import LiveRunner, _mode_to_source
+from ..regime.switch_logic import (
+    SessionInfo,
+    classification_due,
+    current_session,
+    in_closed_gap,
+    last_completed_night,
+)
+from .bar_aggregator import aggregate_bars
+from .live_runner import LiveRunner, _mode_to_source, load_1m_bars_from_csvs
 from .session_store import save_session
 
 logger = logging.getLogger(__name__)
@@ -57,9 +63,11 @@ class RegimeSwitchingRunner(LiveRunner):
         self._strategies_registry = strategies_registry or {}
         self._active_leg: str = "idle"  # "long" | "short" | "idle"
 
+        self._classify_retry_after: datetime | None = None
+
         self._manager = RegimeManager(
             self.bot_dir, regime_cfg,
-            bars_provider=bars_provider,
+            bars_provider=bars_provider or self._classifier_bars,
         )
         # Write an inspectable placeholder regime_state.json at deploy time
         # so the bot folder reflects regime status before the first
@@ -85,16 +93,16 @@ class RegimeSwitchingRunner(LiveRunner):
             now = now.replace(tzinfo=_TZ_TAIPEI)
 
         lines = []
-        slot = session_slot(now)
-        minutes_to_close = self._minutes_until_session_close(now)
 
-        # T2: Record session P&L at session end (before classification)
-        self._maybe_record_session(now, slot, minutes_to_close)
-
-        # T1: Classify at NIGHT end
-        classified = self._maybe_classify(now, slot, minutes_to_close)
+        # T1: Classify at NIGHT end — BEFORE the P&L record, so the record
+        # lands on the freshly appended classification row instead of
+        # spawning a second standalone row for the same session.
+        classified = self._maybe_classify(now)
         if classified:
             lines.append(f"[REGIME] Classified: {classified.action}")
+
+        # T2: Record session P&L at session end
+        self._maybe_record_session(now)
 
         # T3: Apply pending recommendation in closed gap
         applied = self._maybe_apply_pending(now)
@@ -103,62 +111,107 @@ class RegimeSwitchingRunner(LiveRunner):
 
         return lines
 
-    def _maybe_classify(self, now, slot, minutes_to_close) -> object | None:
+    def _maybe_classify(self, now) -> object | None:
+        if self._classify_retry_after is not None and now < self._classify_retry_after:
+            return None
         last_assessed = self._manager._state.last_assessed
-        if not should_classify(now, slot, last_assessed, minutes_to_close):
+        sess = classification_due(now, last_assessed)
+        if sess is None:
             return None
 
-        session_date, _ = slot
-        rec = self._manager.classify_session(session_date, "NIGHT")
-        if rec is not None:
-            self._pending_recommendation = {
-                "date": session_date, "action": rec.action,
-                "strategy": rec.strategy_name, "qty_scale": rec.qty_scale,
-                "reason": rec.reason,
-            }
-            self._emit("on_status",
-                        f"[REGIME] Classified {session_date}: {rec.action} ({rec.strategy_name})")
+        catch_up = now >= sess.close_dt
+        rec = self._manager.classify_session(sess.open_date, "NIGHT")
+        if rec is None:
+            # Insufficient bars or classifier error. The post-close
+            # catch-up trigger would otherwise retry (and warn) on every
+            # 30s poll until the next night is assessed — back off.
+            self._classify_retry_after = now + timedelta(minutes=30)
+            return None
+        self._classify_retry_after = None
+
+        self._pending_recommendation = {
+            "date": sess.open_date, "action": rec.action,
+            "strategy": rec.strategy_name, "qty_scale": rec.qty_scale,
+            "reason": rec.reason,
+        }
+        tag = " (catch-up)" if catch_up else ""
+        self._emit("on_status",
+                    f"[REGIME] Classified {sess.open_date}{tag}: {rec.action} ({rec.strategy_name})")
         return rec
 
-    def _maybe_record_session(self, now, slot, minutes_to_close):
-        if minutes_to_close > 2:
+    def _maybe_record_session(self, now):
+        sess = current_session(now)
+        if sess is None:
+            return  # gap / weekend / holiday — no phantom rows
+        if (sess.close_dt - now).total_seconds() > 120:
             return
-        session_date, session_type = slot
-        key = (session_date, session_type)
+        key = (sess.open_date, sess.slot)
         if key in self._recorded_sessions:
             return
         self._recorded_sessions.add(key)
+        self._record_session(sess)
 
-        # Compute session P&L from own broker trades
-        pnl, n_trades = self._compute_session_pnl(session_date, session_type)
+    def _record_session(self, sess: SessionInfo):
+        pnl, n_trades = self._compute_session_pnl(sess)
         strategy_name = self.strategy_display_name if self._active_leg != "idle" else "idle"
         self._manager.do_record_session_result(
-            session_date, session_type, pnl, n_trades,
+            sess.open_date, sess.slot, pnl, n_trades,
             strategy_active=strategy_name,
             trading_mode=self.trading_mode,
         )
         self._emit("on_status",
-                    f"[REGIME] Recorded {session_type} P&L: {pnl:+} ({n_trades} trades)")
+                    f"[REGIME] Recorded {sess.slot} P&L: {pnl:+} ({n_trades} trades)")
 
-    def _compute_session_pnl(self, session_date: str, session_type: str) -> tuple[float, int]:
-        """Sum P&L of trades closed in this session window."""
+    def _compute_session_pnl(self, sess: SessionInfo) -> tuple[float, int]:
+        """Sum P&L of trades whose exit falls inside this session's window.
+
+        Window-based (open_dt..close_dt), not calendar-date-based: the
+        night session straddles midnight, so a date-only match dropped
+        pre-midnight exits and double-counted post-midnight exits into
+        the same date's DAY row. exit_dt strings ("YYYY-MM-DD HH:MM",
+        sometimes with seconds from force-close) compare
+        lexicographically == chronologically once sliced to minutes.
+        """
+        lo = sess.open_dt.strftime("%Y-%m-%d %H:%M")
+        hi = sess.close_dt.strftime("%Y-%m-%d %H:%M")
         pnl = 0.0
         count = 0
         for t in self.broker.trades:
-            if not t.exit_dt:
-                continue
-            try:
-                exit_date = t.exit_dt[:10]
-            except (TypeError, IndexError):
-                continue
-            if exit_date == session_date:
+            exit_dt = (t.exit_dt or "")[:16]
+            if lo <= exit_dt <= hi:
                 pnl += t.pnl
                 count += 1
         return pnl, count
 
+    def _discard_pending(self, reason: str) -> None:
+        """Drop the pending recommendation permanently (mark executed on
+        disk so a restart does not re-arm it)."""
+        self._pending_recommendation = None
+        executed_at = datetime.now(_TZ_TAIPEI).strftime("%Y-%m-%d %H:%M:%S")
+        self._manager.mark_recommendation_executed(executed_at)
+        logger.warning("[REGIME] Discarded pending recommendation: %s", reason)
+        self._emit("on_status", f"[REGIME] Discarded recommendation: {reason}")
+
     def _maybe_apply_pending(self, now) -> str | None:
         if self._pending_recommendation is None:
             return None
+
+        rec = self._pending_recommendation
+
+        # Staleness gate: a recommendation belongs to the night it
+        # classified. If a NEWER night has completed since (apply blocked
+        # for days, or re-armed after a long outage), acting on it would
+        # trade tomorrow on stale data — a fresh classification should
+        # decide instead (classify runs before apply in the same poll;
+        # this only triggers when that classification couldn't produce).
+        completed = last_completed_night(now)
+        if (completed is not None and rec.get("date", "")
+                and rec["date"] < completed.open_date):
+            self._discard_pending(
+                f"stale — assessed {rec.get('date')}, latest completed "
+                f"night is {completed.open_date}")
+            return None
+
         if not in_closed_gap(now):
             return None
         # Gates: flat, no veto, not in replay
@@ -171,9 +224,7 @@ class RegimeSwitchingRunner(LiveRunner):
         if self.suppress_strategy or self._is_reloading:
             return None
 
-        rec = self._pending_recommendation
         action = rec.get("action", "hold")
-        strategy_name = rec.get("strategy", "")
         result = None
 
         try:
@@ -187,15 +238,25 @@ class RegimeSwitchingRunner(LiveRunner):
                 result = "hold (no change)"
             else:
                 result = f"unknown action: {action}"
+        except ValueError as e:
+            # Permanent config error (leg strategy missing from the
+            # registry) — retrying every 30s forever is useless.
+            logger.exception("[REGIME] Unrecoverable apply error: %s", e)
+            self._discard_pending(f"apply failed permanently: {e}")
+            return None
         except Exception as e:
+            # Transient (e.g. swap refused pending more 1-min history) —
+            # keep the recommendation armed for the next poll.
             logger.exception("[REGIME] Error applying recommendation: %s", e)
             self._emit("on_status", f"[REGIME] Apply error: {e}")
             return None
 
-        # Mark executed
-        self._pending_recommendation = None
+        # Mark executed on disk FIRST, then drop the in-memory pending —
+        # the reverse order could re-apply after a restart if the state
+        # write failed silently.
         executed_at = datetime.now(_TZ_TAIPEI).strftime("%Y-%m-%d %H:%M:%S")
         self._manager.mark_recommendation_executed(executed_at)
+        self._pending_recommendation = None
         self._auto_save_session()
         self._emit("on_status", f"[REGIME] Applied: {result}")
         return result
@@ -223,21 +284,43 @@ class RegimeSwitchingRunner(LiveRunner):
         self.regime_idle = True
         return "sit_out (idle)"
 
-    # ── Session helpers ──
+    # ── Classifier bar supply ──
 
-    def _minutes_until_session_close(self, now: datetime) -> float:
-        """Estimate minutes until the current session's close."""
-        minutes = now.hour * 60 + now.minute
-        # DAY session: closes at 13:45
-        if 525 <= minutes < 826:
-            return max(0, 825 - minutes)
-        # NIGHT session: closes at 05:00 (next day if after 15:00)
-        if minutes >= 900:
-            return (24 * 60 - minutes) + 300
-        if minutes < 300:
-            return 300 - minutes
-        # In a gap — return large number
-        return 999
+    def _classifier_bars(self) -> list:
+        """Default bars provider for regime classification.
+
+        Prefers the in-memory aggregated bars — seeded at deploy by
+        ``feed_warmup_bars()`` with ~2 weeks of KLine history — so a
+        fresh bot can classify from its first night instead of waiting
+        days for its own CSVs to reach 52 classify-interval bars. Falls
+        back to the CSV 1-min history whenever that yields more
+        classify-interval bars (e.g. after a cross-timeframe swap
+        rebuild dropped the warmup bars) or when the target interval
+        cannot be re-binned into the classify interval (H4/daily legs).
+
+        Reads ``self._aggregated_bars`` at call time — do NOT capture
+        the list object; ``_rebuild_timeframe`` rebinds it (issue #43).
+        """
+        interval = self._regime_cfg.classify_interval
+        candidates: list[list] = []
+        if 0 < self.target_interval <= interval:
+            # Dedup+sort defensively: a mid-gap deploy can append a
+            # tick-replayed session behind warmup bars that already
+            # cover it (warmup bars are not in _seen_1m_dts for >1m
+            # timeframes), which would spam out-of-order warnings.
+            mem = sorted({b.dt: b for b in self._aggregated_bars}.values(),
+                         key=lambda b: b.dt)
+            if mem:
+                candidates.append(mem)
+        csv_bars = load_1m_bars_from_csvs(self.bot_dir, self.symbol)
+        if csv_bars:
+            candidates.append(csv_bars)
+        if not candidates:
+            return []
+        if len(candidates) == 1:
+            return candidates[0]
+        return max(candidates,
+                   key=lambda bs: len(aggregate_bars(bs, interval)))
 
     # ── Session persistence (override) ──
 
@@ -298,24 +381,25 @@ class RegimeSwitchingRunner(LiveRunner):
     # ── Stop (override) ──
 
     def stop(self):
-        """Record in-progress session result before teardown."""
-        try:
-            now = datetime.now(_TZ_TAIPEI)
-            slot = session_slot(now)
-            session_date, session_type = slot
-            key = (session_date, session_type)
-            if key not in self._recorded_sessions:
-                self._recorded_sessions.add(key)
-                pnl, n_trades = self._compute_session_pnl(session_date, session_type)
-                strategy_name = self.strategy_display_name if self._active_leg != "idle" else "idle"
-                self._manager.do_record_session_result(
-                    session_date, session_type, pnl, n_trades,
-                    strategy_active=strategy_name,
-                    trading_mode=self.trading_mode,
-                )
-        except Exception as e:
-            logger.warning("[REGIME] Error recording session on stop: %s", e)
-        return super().stop()
+        """Record the in-progress session result on teardown.
+
+        Runs AFTER ``super().stop()`` so the force-close trade it may
+        append is included in the recorded P&L. Recording is NOT skipped
+        when the close-window record already fired — the store updates
+        the existing row in place, so this just refreshes it with the
+        final trade set. A stop during a gap/weekend records nothing
+        (the session-end record already covered the last session).
+        """
+        now = datetime.now(_TZ_TAIPEI)
+        sess = current_session(now)
+        summary = super().stop()
+        if sess is not None:
+            try:
+                self._recorded_sessions.add((sess.open_date, sess.slot))
+                self._record_session(sess)
+            except Exception as e:
+                logger.warning("[REGIME] Error recording session on stop: %s", e)
+        return summary
 
     # ── Status ──
 

--- a/src/regime/manager.py
+++ b/src/regime/manager.py
@@ -21,6 +21,22 @@ from .store import (
 
 logger = logging.getLogger(__name__)
 
+# Regime enum value → bilingual display label for Discord notifications.
+# DISPLAY ONLY — the stored raw_regime/effective_regime values (state file,
+# history CSV, pattern-matching in the state machine/selector) stay as the
+# bare English enum. Never feed a translated label back into stored state.
+_REGIME_LABELS = {
+    "trending-up": "上升趨勢 trending-up",
+    "trending-down": "下降趨勢 trending-down",
+    "range-bound": "盤整 range-bound",
+    "transitional": "過渡期 transitional",
+    "unknown": "未知 unknown",
+}
+
+
+def _regime_label(regime: str) -> str:
+    """Bilingual display label for a regime enum value (falls back to raw)."""
+    return _REGIME_LABELS.get(regime, regime)
 
 class RegimeManager:
     def __init__(
@@ -210,8 +226,8 @@ class RegimeManager:
                         "deploy_short_half": "做空半倉 SHORT½", "sit_out": "觀望 SIT OUT",
                         "hold": "維持 HOLD"}.get(rec.action, rec.action)
         msg = (f"📊 **Regime 建議** — {session_date}\n"
-               f"原始 Raw: `{self._state.raw_regime}` (ADX {self._state.last_features.get('adx', 0):.1f})\n"
-               f"有效 Effective: `{self._state.effective_regime}` (since {self._state.effective_since})\n"
+               f"原始 Raw: `{_regime_label(self._state.raw_regime)}` (ADX {self._state.last_features.get('adx', 0):.1f})\n"
+               f"有效 Effective: `{_regime_label(self._state.effective_regime)}` (since {self._state.effective_since})\n"
                f"建議 Recommendation: **{action_label}**"
                + (f" — `{rec.strategy_name}`" if rec.strategy_name else "")
                + f"\n理由 Reason: {rec.reason}")

--- a/src/regime/manager.py
+++ b/src/regime/manager.py
@@ -25,6 +25,23 @@ logger = logging.getLogger(__name__)
 # 50 plus headroom for the leading/trailing partial aggregation bars.
 MIN_CLASSIFY_BARS = 52
 
+# Regime enum value → bilingual display label for Discord notifications.
+# DISPLAY ONLY — the stored raw_regime/effective_regime values (state file,
+# history CSV, pattern-matching in the state machine/selector) stay as the
+# bare English enum. Never feed a translated label back into stored state.
+_REGIME_LABELS = {
+    "trending-up": "上升趨勢 trending-up",
+    "trending-down": "下降趨勢 trending-down",
+    "range-bound": "盤整 range-bound",
+    "transitional": "過渡期 transitional",
+    "unknown": "未知 unknown",
+}
+
+
+def _regime_label(regime: str) -> str:
+    """Bilingual display label for a regime enum value (falls back to raw)."""
+    return _REGIME_LABELS.get(regime, regime)
+
 
 class RegimeManager:
     def __init__(
@@ -214,8 +231,8 @@ class RegimeManager:
                         "deploy_short_half": "做空半倉 SHORT½", "sit_out": "觀望 SIT OUT",
                         "hold": "維持 HOLD"}.get(rec.action, rec.action)
         msg = (f"📊 **Regime 建議** — {session_date}\n"
-               f"原始 Raw: `{self._state.raw_regime}` (ADX {self._state.last_features.get('adx', 0):.1f})\n"
-               f"有效 Effective: `{self._state.effective_regime}` (since {self._state.effective_since})\n"
+               f"原始 Raw: `{_regime_label(self._state.raw_regime)}` (ADX {self._state.last_features.get('adx', 0):.1f})\n"
+               f"有效 Effective: `{_regime_label(self._state.effective_regime)}` (since {self._state.effective_since})\n"
                f"建議 Recommendation: **{action_label}**"
                + (f" — `{rec.strategy_name}`" if rec.strategy_name else "")
                + f"\n理由 Reason: {rec.reason}")

--- a/src/regime/manager.py
+++ b/src/regime/manager.py
@@ -21,6 +21,10 @@ from .store import (
 
 logger = logging.getLogger(__name__)
 
+# Minimum classify-interval (HTF) bars required to classify: EMA-50 needs
+# 50 plus headroom for the leading/trailing partial aggregation bars.
+MIN_CLASSIFY_BARS = 52
+
 
 class RegimeManager:
     def __init__(
@@ -175,7 +179,7 @@ class RegimeManager:
             if not bars:
                 return None
             bars_htf = aggregate_bars(bars, self.cfg.classify_interval)
-            if len(bars_htf) < 52:
+            if len(bars_htf) < MIN_CLASSIFY_BARS:
                 return None
             highs = [b.high for b in bars_htf]
             lows = [b.low for b in bars_htf]

--- a/src/regime/selector.py
+++ b/src/regime/selector.py
@@ -26,30 +26,30 @@ class StrategySelector:
             action_map = {"long": "deploy_long", "short": "deploy_short", "sit_out": "sit_out"}
             action = action_map.get(state.manual_override, "hold")
             name = cfg.long_strategy if action == "deploy_long" else (cfg.short_strategy if action == "deploy_short" else "")
-            return Recommendation(action, name, reason=f"manual override: {state.manual_override}")
+            return Recommendation(action, name, reason=f"手動覆寫 manual override: {state.manual_override}")
 
         # Paused
         if state.last_features.get("_paused"):
-            return Recommendation("hold", "", reason="flip-counter pause active")
+            return Recommendation("hold", "", reason="翻轉計數暫停中 flip-counter pause active")
 
         # Vol spike
         if state.last_features.get("_vol_spike"):
-            return Recommendation("sit_out", "", reason="volatility spike — ATR ratio exceeded threshold")
+            return Recommendation("sit_out", "", reason="波動突增 volatility spike — ATR ratio exceeded threshold")
 
         regime = state.effective_regime
         features = state.last_features
 
         if regime == "trending-up":
-            return Recommendation("deploy_long", cfg.long_strategy, reason="trending-up confirmed")
+            return Recommendation("deploy_long", cfg.long_strategy, reason="上升趨勢確認 trending-up confirmed")
         elif regime == "trending-down":
-            return Recommendation("deploy_short", cfg.short_strategy, reason="trending-down confirmed")
+            return Recommendation("deploy_short", cfg.short_strategy, reason="下降趨勢確認 trending-down confirmed")
         elif regime == "range-bound":
             bearish = features.get("ema_slope", 0) < 0 and features.get("direction") == "bearish"
             if bearish:
                 if cfg.range_bias_action == "short_half":
                     return Recommendation("deploy_short_half", cfg.short_strategy, qty_scale=0.5,
-                                         reason="range-bound with bearish bias — half size")
-                return Recommendation("sit_out", "", reason="range-bound with bearish bias — sit out")
-            return Recommendation("sit_out", "", reason="range-bound — neutral/bullish, sit out")
+                                         reason="盤整偏空 — 半倉 range-bound with bearish bias — half size")
+                return Recommendation("sit_out", "", reason="盤整偏空 — 觀望 range-bound with bearish bias — sit out")
+            return Recommendation("sit_out", "", reason="盤整中性/偏多 — 觀望 range-bound — neutral/bullish, sit out")
         else:
-            return Recommendation("hold", "", reason=f"unknown/transitional regime: {regime}")
+            return Recommendation("hold", "", reason=f"未知/過渡期 unknown/transitional regime: {regime}")

--- a/src/regime/state_machine.py
+++ b/src/regime/state_machine.py
@@ -23,6 +23,11 @@ class RegimeConfig:
     max_flips: int = 3
     flip_window: int = 10
     pause_sessions: int = 5
+    # Fast-track threshold: a single session with ADX above this confirms
+    # a regime change without waiting confirm_sessions. Only active while
+    # adx_strong > adx_enter — otherwise every trending read would
+    # fast-track and raising adx_enter would silently disable hysteresis.
+    adx_strong: float = 30.0
     long_strategy: str = ""
     short_strategy: str = ""
     range_bias_action: str = "sit_out"   # "sit_out" | "short_half"
@@ -38,6 +43,10 @@ class RegimeState:
     pending_label: str = ""
     pending_count: int = 0
     flip_history: list = field(default_factory=list)
+    # session_count values at which flips were confirmed — the actual
+    # sliding-window data for the flip-counter pause. flip_history keeps
+    # the human-readable dates for display/state inspection.
+    flip_sessions: list = field(default_factory=list)
     paused_until_session: int = 0       # session index counter
     session_count: int = 0
     manual_override: str = "auto"
@@ -86,7 +95,7 @@ class RegimeStateMachine:
         if raw == "transitional":
             s.pending_count = 0   # reset streak but don't change effective
         else:
-            strong = adx > 30
+            strong = cfg.adx_strong > cfg.adx_enter and adx > cfg.adx_strong
             if raw == s.pending_label:
                 s.pending_count += 1
             else:
@@ -99,10 +108,16 @@ class RegimeStateMachine:
                 s.effective_since = session_date
                 s.pending_count = 0
                 s.flip_history.append(session_date)
-                # Trim to flip_window
                 s.flip_history = s.flip_history[-cfg.flip_window:]
-                # Check if flip count triggers pause
-                if len(s.flip_history) >= cfg.max_flips:
+                # Flip-counter pause: max_flips within the last flip_window
+                # SESSIONS (a true sliding window — lifetime flip count is
+                # irrelevant, so an old bot doesn't pause on every flip).
+                s.flip_sessions.append(s.session_count)
+                s.flip_sessions = [
+                    c for c in s.flip_sessions
+                    if s.session_count - c < cfg.flip_window
+                ]
+                if len(s.flip_sessions) >= cfg.max_flips:
                     s.paused_until_session = s.session_count + cfg.pause_sessions
 
         s.last_features["_vol_spike"] = vol_spike

--- a/src/regime/store.py
+++ b/src/regime/store.py
@@ -26,6 +26,38 @@ _V2_HEADER = [
 ]
 
 
+# File-level marker for the last_assessed keying convention. Files
+# written before v2.16 stamped the night's CLOSE date; current code
+# stamps the OPEN date. Absence of the marker on a non-empty key means
+# the file is old-format and must be translated once at load.
+_KEY_FORMAT = "open-date"
+
+
+def _migrate_close_date_key(last_assessed: str) -> str:
+    """Translate a pre-v2.16 close-date key to its open-date equivalent.
+
+    An old stamp "2026-07-16|NIGHT" was written ~04:58 on 07-16 and
+    covered the night that OPENED on the prior trading day — exactly
+    what ``latest_night_session`` returns for that close-window moment.
+    Translating (instead of clearing) avoids both failure modes: a
+    colliding key would silently skip the next night, while a cleared
+    key would re-assess an already-assessed night and double-step the
+    hysteresis state machine.
+    """
+    from datetime import datetime, timedelta, timezone
+    from .switch_logic import latest_night_session
+    try:
+        date_part = last_assessed.split("|")[0]
+        stamped = datetime.strptime(date_part, "%Y-%m-%d").replace(
+            hour=4, minute=58, tzinfo=timezone(timedelta(hours=8)))
+        covered = latest_night_session(stamped)
+        return covered.key if covered else ""
+    except Exception:
+        logger.warning("[REGIME] Could not migrate last_assessed %r — clearing",
+                       last_assessed)
+        return ""
+
+
 def load_state(path: str) -> RegimeState:
     if not os.path.exists(path):
         return RegimeState()
@@ -39,12 +71,18 @@ def load_state(path: str) -> RegimeState:
     for k, v in d.items():
         if hasattr(s, k):
             setattr(s, k, v)
+    if s.last_assessed and d.get("key_format") != _KEY_FORMAT:
+        migrated = _migrate_close_date_key(s.last_assessed)
+        logger.info("[REGIME] Migrated last_assessed %r → %r (open-date keying)",
+                    s.last_assessed, migrated)
+        s.last_assessed = migrated
     return s
 
 
 def save_state(path: str, state: RegimeState, rec: Recommendation, session_date: str):
     import dataclasses
     d = dataclasses.asdict(state)
+    d["key_format"] = _KEY_FORMAT
     d["next_session"] = {
         "date": session_date, "action": rec.action,
         "strategy": rec.strategy_name, "qty_scale": rec.qty_scale,

--- a/src/regime/store.py
+++ b/src/regime/store.py
@@ -106,6 +106,32 @@ def migrate_legacy_history(csv_path: str) -> None:
         logger.warning("[REGIME] Could not migrate history: %s", e)
 
 
+def _atomic_write_rows(csv_path: str, rows: list) -> None:
+    """Write all CSV rows via temp + fsync + os.replace.
+
+    A crash mid-write must never truncate the live history file — a
+    zero-byte/partial file would later be mistaken for v1 by
+    ``migrate_legacy_history`` and archived away.
+    """
+    tmp = csv_path + ".tmp"
+    with open(tmp, "w", newline="", encoding="utf-8") as f:
+        csv.writer(f).writerows(rows)
+        f.flush()
+        os.fsync(f.fileno())
+    os.replace(tmp, csv_path)
+
+
+def _read_rows(csv_path: str) -> list:
+    """Read history rows, always returning a header as row 0."""
+    if not os.path.exists(csv_path):
+        return [list(_V2_HEADER)]
+    with open(csv_path, newline="", encoding="utf-8") as f:
+        rows = list(csv.reader(f))
+    if not rows:
+        return [list(_V2_HEADER)]
+    return rows
+
+
 def append_history(
     csv_path: str,
     session_date: str,
@@ -118,28 +144,25 @@ def append_history(
     trading_mode: str = "",
 ):
     """Append a classification row to regime_history.csv (v2 schema)."""
-    exists = os.path.exists(csv_path)
-    with open(csv_path, "a", newline="", encoding="utf-8") as f:
-        w = csv.writer(f)
-        if not exists:
-            w.writerow(_V2_HEADER)
-        feat = state.last_features
-        w.writerow([
-            session_date, "NIGHT",
-            round(feat.get("adx", 0), 1),
-            round(feat.get("plus_di", 0), 1),
-            round(feat.get("minus_di", 0), 1),
-            round(feat.get("atr_ratio", 0), 2),
-            round(feat.get("ema_slope", 0), 1),
-            feat.get("last_close", ""),
-            state.raw_regime, state.effective_regime,
-            state.pending_count,
-            rec.action, rec.strategy_name,
-            "", state.manual_override,
-            "", "",  # pnl, trades — filled by record_session_result
-            strategy_active,
-            str(applied).lower(), applied_at, trading_mode,
-        ])
+    rows = _read_rows(csv_path)
+    feat = state.last_features
+    rows.append([
+        session_date, "NIGHT",
+        round(feat.get("adx", 0), 1),
+        round(feat.get("plus_di", 0), 1),
+        round(feat.get("minus_di", 0), 1),
+        round(feat.get("atr_ratio", 0), 2),
+        round(feat.get("ema_slope", 0), 1),
+        feat.get("last_close", ""),
+        state.raw_regime, state.effective_regime,
+        state.pending_count,
+        rec.action, rec.strategy_name,
+        "", state.manual_override,
+        "", "",  # pnl, trades — filled by record_session_result
+        strategy_active,
+        str(applied).lower(), applied_at, trading_mode,
+    ])
+    _atomic_write_rows(csv_path, rows)
 
 
 def record_session_result(
@@ -153,52 +176,37 @@ def record_session_result(
 ):
     """Record a session's P&L directly from the switching runner's broker.
 
-    For NIGHT sessions where a classification row already exists (pnl
-    column blank), backfills that row.  For DAY sessions (or NIGHT
-    sessions with no prior classification row), appends a standalone
-    result row with ``decision=""``.
+    Update-or-append, keyed by (date, session): if a row for this
+    session already exists — a classification row awaiting backfill OR
+    an earlier result row — its pnl/trades are OVERWRITTEN; otherwise a
+    standalone result row is appended.  The caller recomputes the
+    session total from the full trade list each time, so re-recording
+    is idempotent: a stop() right after the close-window record, or a
+    restart that records the same session again, updates the row in
+    place instead of appending a double-counted duplicate.
     """
-    if not os.path.exists(csv_path):
-        # Create with header + standalone row
-        with open(csv_path, "w", newline="", encoding="utf-8") as f:
-            w = csv.writer(f)
-            w.writerow(_V2_HEADER)
-            w.writerow(_result_row(session_date, session_slot, pnl, trades,
-                                   strategy_active, trading_mode))
-        return
+    rows = _read_rows(csv_path)
 
-    with open(csv_path, newline="", encoding="utf-8") as f:
-        rows = list(csv.reader(f))
+    session_col = _V2_HEADER.index("session")
+    pnl_col = _V2_HEADER.index("pnl")
+    trades_col = _V2_HEADER.index("trades")
+    active_col = _V2_HEADER.index("strategy_active")
+    mode_col = _V2_HEADER.index("trading_mode")
 
-    # Try to backfill an existing classification row (matching date+session, blank pnl)
-    backfilled = False
-    session_col = _V2_HEADER.index("session")  # 1
-    pnl_col = _V2_HEADER.index("pnl")         # 15
-    trades_col = _V2_HEADER.index("trades")    # 16
-    active_col = _V2_HEADER.index("strategy_active")  # 17
-    mode_col = _V2_HEADER.index("trading_mode")        # 20
     for i in range(len(rows) - 1, 0, -1):
-        if (len(rows[i]) > pnl_col
+        if (len(rows[i]) > mode_col
                 and rows[i][0] == session_date
-                and rows[i][session_col] == session_slot
-                and rows[i][pnl_col] == ""):
+                and rows[i][session_col] == session_slot):
             rows[i][pnl_col] = str(pnl)
             rows[i][trades_col] = str(trades)
-            if len(rows[i]) > active_col and not rows[i][active_col]:
-                rows[i][active_col] = strategy_active
-            if len(rows[i]) > mode_col and not rows[i][mode_col]:
-                rows[i][mode_col] = trading_mode
-            backfilled = True
+            rows[i][active_col] = strategy_active
+            rows[i][mode_col] = trading_mode
             break
-
-    if backfilled:
-        with open(csv_path, "w", newline="", encoding="utf-8") as f:
-            csv.writer(f).writerows(rows)
     else:
-        with open(csv_path, "a", newline="", encoding="utf-8") as f:
-            csv.writer(f).writerow(
-                _result_row(session_date, session_slot, pnl, trades,
-                            strategy_active, trading_mode))
+        rows.append(_result_row(session_date, session_slot, pnl, trades,
+                                strategy_active, trading_mode))
+
+    _atomic_write_rows(csv_path, rows)
 
 
 def _result_row(date, session, pnl, trades, strategy_active, trading_mode):

--- a/src/regime/switch_logic.py
+++ b/src/regime/switch_logic.py
@@ -2,12 +2,22 @@
 
 Session-boundary detection, classification triggers, swap decisions —
 all testable without COM, Tk, or live infrastructure.
+
+Session identity convention: a trading session is identified by its OPEN
+date. The midnight-straddling night session (15:00 → 05:00 next day)
+keeps a single stable identity — e.g. the night opening Tue 15:00 and
+closing Wed 05:00 is ``("<Tue date>", "NIGHT")`` throughout. This is the
+key used for classification dedup, P&L recording, and history rows.
+(``session_slot`` below predates this and returns the CALENDAR date at
+the queried moment; it is kept for the daily-report session key where
+calendar-date semantics are fine.)
 """
 
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
+from typing import NamedTuple
 
 logger = logging.getLogger(__name__)
 
@@ -81,26 +91,135 @@ def in_closed_gap(now: datetime | None = None) -> bool:
     return False
 
 
-def should_classify(
-    now: datetime,
-    session_slot_result: tuple[str, str],
-    last_assessed_key: str,
-    minutes_to_close: float,
-) -> bool:
-    """Whether the runner should fire classification right now.
+class SessionInfo(NamedTuple):
+    """A concrete trading session, identified by its OPEN date."""
+    open_date: str        # YYYY-MM-DD of the session OPEN
+    slot: str             # "DAY" | "NIGHT"
+    open_dt: datetime     # tz-aware Taipei
+    close_dt: datetime    # tz-aware Taipei
 
-    Only fires on NIGHT sessions, within 2 minutes of close, and only
-    once per on-disk dedup key.
+    @property
+    def key(self) -> str:
+        return f"{self.open_date}|{self.slot}"
+
+
+def _norm_tpe(now: datetime | None) -> datetime:
+    if now is None:
+        return datetime.now(_TZ_TAIPEI)
+    if now.tzinfo is None:
+        return now.replace(tzinfo=_TZ_TAIPEI)
+    return now
+
+
+def _is_closed_day(d: date) -> bool:
+    """True when TAIFEX has no sessions opening on ``d``.
+
+    Delegates to the market-data holiday calendar (weekends + TW public
+    holidays + overrides); degrades to a weekend-only check if the
+    holidays module is unavailable (mis-bundled frozen EXE, issue #58).
     """
-    _date, slot = session_slot_result
-    if slot != "NIGHT":
-        return False
-    if minutes_to_close > 2:
-        return False
-    dedup_key = f"{_date}|NIGHT"
-    if dedup_key == last_assessed_key:
-        return False
-    return True
+    try:
+        from src.market_data.holidays import is_taifex_holiday
+        return is_taifex_holiday(d)
+    except Exception:
+        return d.weekday() >= 5
+
+
+def current_session(now: datetime | None = None) -> SessionInfo | None:
+    """The trading session containing ``now``, or None when the market
+    is closed (intraday gap, weekend, or holiday).
+
+    Unlike ``session_slot``, this returns None outside real sessions —
+    so a Saturday 13:43 poll can no longer masquerade as a DAY session,
+    and the night session is keyed by its OPEN date on both sides of
+    midnight.
+    """
+    now = _norm_tpe(now)
+    minutes = now.hour * 60 + now.minute
+    today = now.date()
+
+    if _DAY_OPEN <= minutes < _DAY_CLOSE:
+        if _is_closed_day(today):
+            return None
+        open_dt = now.replace(hour=8, minute=45, second=0, microsecond=0)
+        close_dt = now.replace(hour=13, minute=45, second=0, microsecond=0)
+        return SessionInfo(today.isoformat(), "DAY", open_dt, close_dt)
+
+    if minutes >= _NIGHT_OPEN:
+        if _is_closed_day(today):
+            return None
+        open_dt = now.replace(hour=15, minute=0, second=0, microsecond=0)
+        return SessionInfo(today.isoformat(), "NIGHT", open_dt,
+                           open_dt + timedelta(hours=14))
+
+    if minutes < _NIGHT_CLOSE:
+        # 00:00-05:00 — carryover of the night that opened yesterday
+        yesterday = today - timedelta(days=1)
+        if _is_closed_day(yesterday):
+            return None
+        open_dt = (now - timedelta(days=1)).replace(
+            hour=15, minute=0, second=0, microsecond=0)
+        return SessionInfo(yesterday.isoformat(), "NIGHT", open_dt,
+                           open_dt + timedelta(hours=14))
+
+    return None
+
+
+def latest_night_session(now: datetime | None = None) -> SessionInfo | None:
+    """The most recently OPENED night session at ``now`` — in progress
+    or already closed. Looks back up to 14 days (long holiday runs).
+    """
+    now = _norm_tpe(now)
+    for back in range(15):
+        d = now.date() - timedelta(days=back)
+        if _is_closed_day(d):
+            continue
+        open_dt = datetime(d.year, d.month, d.day, 15, 0, tzinfo=_TZ_TAIPEI)
+        if open_dt <= now:
+            return SessionInfo(d.isoformat(), "NIGHT", open_dt,
+                               open_dt + timedelta(hours=14))
+    return None
+
+
+def last_completed_night(now: datetime | None = None) -> SessionInfo | None:
+    """The most recent night session that has already CLOSED at ``now``."""
+    now = _norm_tpe(now)
+    sess = latest_night_session(now)
+    if sess is None:
+        return None
+    if now >= sess.close_dt:
+        return sess
+    return latest_night_session(sess.open_dt - timedelta(minutes=1))
+
+
+def classification_due(
+    now: datetime,
+    last_assessed_key: str,
+    window_minutes: float = 2.0,
+) -> SessionInfo | None:
+    """The night session whose classification should fire now, or None.
+
+    Fires in the session's last ``window_minutes`` (the normal 04:58
+    trigger) — or any time AFTER it closed while still unassessed
+    (catch-up: an app hang/sleep across the close window no longer
+    silently skips the day; a catch-up run classifies "as of now", so
+    its features may include bars from the following DAY session).
+
+    Weekend/holiday polls are naturally inert: the latest night session
+    doesn't advance on closed days, so once its key is assessed the
+    check stays None until a new night actually opens.
+    """
+    sess = latest_night_session(now)
+    if sess is None:
+        return None
+    if sess.key == last_assessed_key:
+        return None
+    now = _norm_tpe(now)
+    if now >= sess.close_dt:
+        return sess  # catch-up
+    if (sess.close_dt - now) <= timedelta(minutes=window_minutes):
+        return sess
+    return None
 
 
 def validate_leg_strategies(

--- a/tests/test_deploy_regime_integration.py
+++ b/tests/test_deploy_regime_integration.py
@@ -206,12 +206,18 @@ class TestStatusPoll:
 
     def test_poll_in_day_session(self, tmp_path):
         runner = _make_regime_runner(tmp_path)
+        # Last completed night (opened Wed 07-08) already assessed —
+        # otherwise the catch-up trigger legitimately classifies it here.
+        runner._manager._state.last_assessed = "2026-07-08|NIGHT"
         now = datetime(2026, 7, 9, 10, 0, tzinfo=_TZ_TAIPEI)
         lines = runner.on_status_poll(now)
         assert not any("Classified" in l for l in lines)
 
     def test_poll_in_gap_with_pending(self, tmp_path):
         runner = _make_regime_runner(tmp_path)
+        # Pre-assess the completed night so the catch-up classifier does
+        # not overwrite the hand-crafted pending under test.
+        runner._manager._state.last_assessed = "2026-07-09|NIGHT"
         runner._pending_recommendation = {
             "date": "2026-07-10", "action": "deploy_long",
             "strategy": "StrategyA", "qty_scale": 1.0, "reason": "test",

--- a/tests/test_regime_manager_v2.py
+++ b/tests/test_regime_manager_v2.py
@@ -99,7 +99,7 @@ class TestClassifySession:
         mgr.classify_session("2026-07-09", "NIGHT")
         state_path = os.path.join(bot_dir, "regime_state.json")
         assert os.path.exists(state_path)
-        with open(state_path) as f:
+        with open(state_path, encoding="utf-8") as f:
             d = json.load(f)
         assert d["last_assessed"] == "2026-07-09|NIGHT"
         ns = d["next_session"]

--- a/tests/test_regime_manager_v2.py
+++ b/tests/test_regime_manager_v2.py
@@ -137,6 +137,56 @@ class TestRecordResult:
         assert rows[1][_V2_HEADER.index("trades")] == "3"
 
 
+class TestRecordUpdateInPlace:
+    def test_re_record_updates_row_not_duplicate(self, tmp_path):
+        """Re-recording the same session (stop right after the close-window
+        record, or a restart) must update the row in place — the old code
+        appended a second standalone row, double-counting the session."""
+        bot_dir = str(tmp_path / "TX00_test")
+        os.makedirs(bot_dir, exist_ok=True)
+        mgr = RegimeManager(bot_dir, _make_cfg(), bars_provider=lambda: _make_bars())
+
+        mgr.do_record_session_result("2026-07-09", "DAY", 50.0, 3,
+                                     strategy_active="LongA", trading_mode="paper")
+        mgr.do_record_session_result("2026-07-09", "DAY", 80.0, 4,
+                                     strategy_active="LongA", trading_mode="paper")
+
+        hist_path = os.path.join(bot_dir, "regime_history.csv")
+        with open(hist_path, newline="") as f:
+            rows = list(csv.reader(f))
+        matching = [r for r in rows[1:] if r[0] == "2026-07-09" and r[1] == "DAY"]
+        assert len(matching) == 1
+        assert matching[0][_V2_HEADER.index("pnl")] == "80.0"
+        assert matching[0][_V2_HEADER.index("trades")] == "4"
+
+    def test_classify_then_record_single_row(self, tmp_path):
+        """With classify-before-record poll ordering, one session ends up
+        as ONE row carrying both the assessment and its P&L."""
+        bot_dir = str(tmp_path / "TX00_test")
+        os.makedirs(bot_dir, exist_ok=True)
+        mgr = RegimeManager(bot_dir, _make_cfg(), bars_provider=lambda: _make_bars())
+
+        mgr.classify_session("2026-07-09", "NIGHT")
+        mgr.do_record_session_result("2026-07-09", "NIGHT", 120.0, 2,
+                                     strategy_active="LongA", trading_mode="paper")
+
+        hist_path = os.path.join(bot_dir, "regime_history.csv")
+        with open(hist_path, newline="") as f:
+            rows = list(csv.reader(f))
+        matching = [r for r in rows[1:] if r[0] == "2026-07-09" and r[1] == "NIGHT"]
+        assert len(matching) == 1
+        assert matching[0][_V2_HEADER.index("adx")] != ""     # classification kept
+        assert matching[0][_V2_HEADER.index("pnl")] == "120.0"  # P&L attached
+
+    def test_no_tmp_file_left_behind(self, tmp_path):
+        bot_dir = str(tmp_path / "TX00_test")
+        os.makedirs(bot_dir, exist_ok=True)
+        mgr = RegimeManager(bot_dir, _make_cfg(), bars_provider=lambda: _make_bars())
+        mgr.classify_session("2026-07-09", "NIGHT")
+        mgr.do_record_session_result("2026-07-09", "NIGHT", 1.0, 1)
+        assert not [f for f in os.listdir(bot_dir) if f.endswith(".tmp")]
+
+
 class TestPendingRecommendation:
     def test_get_pending_after_classify(self, tmp_path):
         bot_dir = str(tmp_path / "TX00_test")

--- a/tests/test_regime_state_machine.py
+++ b/tests/test_regime_state_machine.py
@@ -117,6 +117,38 @@ def test_pause_expires_after_pause_sessions():
     assert not s.last_features.get("_paused")
 
 
+def test_flips_outside_window_do_not_pause():
+    """flip_window is a SLIDING window — 3 flips spread far apart must not
+    pause. Old code counted lifetime flips (trimmed only to the last 10),
+    so after the 3rd flip EVER, every flip paused the bot forever."""
+    m = RegimeStateMachine()
+    cfg = RegimeConfig(enabled=True, max_flips=3, pause_sessions=2, flip_window=5)
+    s = RegimeState()
+    s = _step(m, s, cfg, make_result(adx=35.0, plus_di=30, minus_di=10), "2026-01-01")
+    s = _step(m, s, cfg, make_result(adx=35.0, plus_di=10, minus_di=30), "2026-01-02")
+    # 10 transitional sessions push the window past both flips
+    for i in range(10):
+        s = _step(m, s, cfg, make_result(adx=22.0), f"2026-01-{3 + i:02d}")
+    # 3rd lifetime flip — but only 1 flip within the last 5 sessions
+    s = _step(m, s, cfg, make_result(adx=35.0, plus_di=30, minus_di=10), "2026-01-13")
+    assert s.effective_regime == "trending-up"
+    assert s.paused_until_session == 0
+
+
+def test_raised_adx_enter_does_not_disable_hysteresis():
+    """With adx_enter raised above adx_strong, the fast-track is disabled
+    instead of firing on every trending read (which would silently reduce
+    confirm_sessions to 1)."""
+    m = RegimeStateMachine()
+    cfg = RegimeConfig(enabled=True, confirm_sessions=2, adx_enter=32.0)
+    s = RegimeState()
+    s = _step(m, s, cfg, make_result(adx=35.0), "2026-01-01")
+    assert s.raw_regime == "trending-up"
+    assert s.effective_regime == "unknown"   # one session is NOT enough
+    s = _step(m, s, cfg, make_result(adx=35.0), "2026-01-02")
+    assert s.effective_regime == "trending-up"  # confirmed on the 2nd
+
+
 def test_manual_override_field_preserved_through_step():
     # The state machine does not consume manual_override (the manager does);
     # it must survive a step untouched.

--- a/tests/test_regime_store_v2.py
+++ b/tests/test_regime_store_v2.py
@@ -123,15 +123,18 @@ class TestRecordSessionResult:
         assert rows[0] == _V2_HEADER
         assert len(rows) == 2
 
-    def test_does_not_double_backfill(self, tmp_path):
+    def test_re_record_updates_in_place(self, tmp_path):
         path = str(tmp_path / "history.csv")
         append_history(path, "2026-07-09", _make_state(), _make_rec())
         record_session_result(path, "2026-07-09", "NIGHT", 5000.0, 3)
         record_session_result(path, "2026-07-09", "NIGHT", 9999.0, 9)
         rows = _read_csv(path)
-        # Second call can't backfill because pnl is already filled —
-        # it appends a standalone row instead
-        assert rows[1][_V2_HEADER.index("pnl")] == "5000.0"
+        # Re-recording the same session UPDATES the row (the caller
+        # recomputes the full-session total each time, so latest wins) —
+        # appending would double-count the session on stop()/restart.
+        assert rows[1][_V2_HEADER.index("pnl")] == "9999.0"
+        assert rows[1][_V2_HEADER.index("trades")] == "9"
+        assert len(rows) == 2  # header + the single session row
 
 
 class TestMigrateLegacyHistory:

--- a/tests/test_regime_store_v2.py
+++ b/tests/test_regime_store_v2.py
@@ -12,6 +12,8 @@ from src.regime.store import (
     record_session_result,
     migrate_legacy_history,
     write_placeholder_state,
+    load_state,
+    save_state,
     _V2_HEADER,
 )
 
@@ -135,6 +137,62 @@ class TestRecordSessionResult:
         assert rows[1][_V2_HEADER.index("pnl")] == "9999.0"
         assert rows[1][_V2_HEADER.index("trades")] == "9"
         assert len(rows) == 2  # header + the single session row
+
+
+class TestKeyFormatMigration:
+    """Pre-v2.16 state files stamped last_assessed with the night's CLOSE
+    date; load_state must translate it once to the OPEN-date key so the
+    upgrade neither skips the next night (key collision) nor re-assesses
+    an already-assessed one (cleared key double-stepping hysteresis)."""
+
+    def _write(self, path, d):
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(d, f)
+
+    def test_old_close_date_key_translated(self, tmp_path):
+        # 2026-07-16 is a Thursday; the night that closed 07-16 05:00
+        # opened Wednesday 07-15.
+        path = str(tmp_path / "regime_state.json")
+        self._write(path, {"last_assessed": "2026-07-16|NIGHT"})
+        s = load_state(path)
+        assert s.last_assessed == "2026-07-15|NIGHT"
+
+    def test_old_weekend_phantom_key_translated(self, tmp_path):
+        # An old-code Sunday phantom stamp resolves to the Friday-open
+        # night — the same night Saturday's legitimate stamp covered.
+        path = str(tmp_path / "regime_state.json")
+        self._write(path, {"last_assessed": "2026-07-12|NIGHT"})
+        s = load_state(path)
+        assert s.last_assessed == "2026-07-10|NIGHT"
+
+    def test_new_format_untouched(self, tmp_path):
+        path = str(tmp_path / "regime_state.json")
+        self._write(path, {"last_assessed": "2026-07-15|NIGHT",
+                           "key_format": "open-date"})
+        s = load_state(path)
+        assert s.last_assessed == "2026-07-15|NIGHT"
+
+    def test_empty_key_untouched(self, tmp_path):
+        path = str(tmp_path / "regime_state.json")
+        self._write(path, {"last_assessed": ""})
+        s = load_state(path)
+        assert s.last_assessed == ""
+
+    def test_garbage_key_cleared(self, tmp_path):
+        path = str(tmp_path / "regime_state.json")
+        self._write(path, {"last_assessed": "not-a-date|NIGHT"})
+        s = load_state(path)
+        assert s.last_assessed == ""
+
+    def test_save_stamps_marker_and_round_trips(self, tmp_path):
+        path = str(tmp_path / "regime_state.json")
+        state = _make_state(last_assessed="2026-07-15|NIGHT")
+        save_state(path, state, _make_rec(), "2026-07-15")
+        d = json.loads(open(path, encoding="utf-8").read())
+        assert d["key_format"] == "open-date"
+        # A reload must NOT re-translate a key saved by current code.
+        s = load_state(path)
+        assert s.last_assessed == "2026-07-15|NIGHT"
 
 
 class TestMigrateLegacyHistory:

--- a/tests/test_regime_switching_runner.py
+++ b/tests/test_regime_switching_runner.py
@@ -260,7 +260,7 @@ class TestResumeRearm:
         # Check if anything was classified
         state_path = os.path.join(runner1.bot_dir, "regime_state.json")
         if os.path.exists(state_path):
-            with open(state_path) as f:
+            with open(state_path, encoding="utf-8") as f:
                 d = json.load(f)
             ns = d.get("next_session", {})
             if not ns.get("executed", True):

--- a/tests/test_regime_switching_runner.py
+++ b/tests/test_regime_switching_runner.py
@@ -293,7 +293,7 @@ class TestResumeRearm:
         # Check if anything was classified
         state_path = os.path.join(runner1.bot_dir, "regime_state.json")
         if os.path.exists(state_path):
-            with open(state_path) as f:
+            with open(state_path, encoding="utf-8") as f:
                 d = json.load(f)
             ns = d.get("next_session", {})
             if not ns.get("executed", True):

--- a/tests/test_regime_switching_runner.py
+++ b/tests/test_regime_switching_runner.py
@@ -118,12 +118,45 @@ class TestClassification:
         # Should have classified (or no-op if bars insufficient for this test setup)
         assert isinstance(lines, list)
 
-    def test_day_session_no_classify(self, tmp_path):
+    def test_classify_keyed_by_open_date(self, tmp_path):
+        # The night closing Fri 05:00 opened Thu 15:00 — its key is the
+        # OPEN date (2026-07-09), stable across midnight.
+        runner = _make_runner(tmp_path)
+        now = datetime(2026, 7, 10, 4, 58, tzinfo=_TZ_TAIPEI)
+        runner.on_status_poll(now)
+        assert runner._manager._state.last_assessed == "2026-07-09|NIGHT"
+
+    def test_day_session_no_classify_when_assessed(self, tmp_path):
+        runner = _make_runner(tmp_path)
+        # Last completed night (opened Wed 07-08) already assessed
+        runner._manager._state.last_assessed = "2026-07-08|NIGHT"
+        now = datetime(2026, 7, 9, 12, 0, tzinfo=_TZ_TAIPEI)
+        lines = runner.on_status_poll(now)
+        assert not any("Classified" in l for l in lines)
+
+    def test_catch_up_classify_after_missed_window(self, tmp_path):
+        # A poll long after the night closed (missed 04:58-05:00 window,
+        # or a fresh deploy) classifies the unassessed night late.
         runner = _make_runner(tmp_path)
         now = datetime(2026, 7, 9, 12, 0, tzinfo=_TZ_TAIPEI)
         lines = runner.on_status_poll(now)
-        # Should NOT have classified — it's DAY
-        assert not any("Classified" in l for l in lines)
+        assert any("Classified" in l for l in lines)
+        assert runner._manager._state.last_assessed == "2026-07-08|NIGHT"
+
+    def test_insufficient_bars_backs_off(self, tmp_path):
+        # Classifier failure sets a retry backoff instead of hammering
+        # (and warning) on every 30s poll until the next night.
+        runner = _make_runner(tmp_path)
+        runner._manager._bars_provider = lambda: []
+        now = datetime(2026, 7, 10, 4, 58, tzinfo=_TZ_TAIPEI)
+        runner.on_status_poll(now)
+        assert runner._classify_retry_after is not None
+        # Within the backoff window the manager is not called again
+        calls = []
+        orig = runner._manager.classify_session
+        runner._manager.classify_session = lambda *a, **k: calls.append(a) or orig(*a, **k)
+        runner.on_status_poll(now + timedelta(seconds=30))
+        assert calls == []
 
 
 class TestApplyPending:
@@ -298,3 +331,177 @@ class TestFullCycle:
         gap2 = datetime(2026, 7, 10, 7, 30, tzinfo=_TZ_TAIPEI)
         lines = runner.on_status_poll(gap2)
         # No error, no double-apply
+
+
+def _klines_15m_days(n_days, start="2026-07-01"):
+    """15-min KLine strings spanning ``n_days``, 08:45-18:30 each day
+    (40 bars/day → 10 hourly bars/day after aggregation)."""
+    lines = []
+    day0 = datetime.strptime(start, "%Y-%m-%d")
+    for d in range(n_days):
+        day = day0 + timedelta(days=d)
+        for i in range(40):
+            dt = day.replace(hour=8, minute=45) + timedelta(minutes=15 * i)
+            price = 22000 + d * 100 + i
+            lines.append(
+                f"{dt.strftime('%m/%d/%Y %H:%M')},{price},{price+10},"
+                f"{price-5},{price+3},{50+i}")
+    return lines
+
+
+class TestClassifierBarsPreseed:
+    def _make_bare_runner(self, tmp_path):
+        """Runner with NO bars_provider — exercises the default
+        _classifier_bars provider."""
+        return RegimeSwitchingRunner(
+            LongStrategy(), "TX00", log_dir=str(tmp_path),
+            bot_name="preseed",
+            regime_cfg=_make_cfg(),
+            long_strategy_name="TestLong",
+            short_strategy_name="TestShort",
+            strategies_registry=REGISTRY,
+        )
+
+    def test_warmup_preseeds_classifier(self, tmp_path):
+        """Warmup KLine history alone must let a fresh bot (empty bot
+        dir, no CSVs) classify — the old default provider read only the
+        bot's own CSVs, forcing ~4 trading days of cold start."""
+        runner = self._make_bare_runner(tmp_path)
+        runner.feed_warmup_bars(_klines_15m_days(7))  # ~70 hourly bars
+        runner._is_reloading = False
+        rec = runner._manager.classify_session("2026-07-08", "NIGHT")
+        assert rec is not None
+
+    def test_no_warmup_no_csv_returns_empty(self, tmp_path):
+        runner = self._make_bare_runner(tmp_path)
+        assert runner._classifier_bars() == []
+
+    def test_high_timeframe_falls_back_to_csv(self, tmp_path):
+        # H4/daily bars cannot be re-binned down to the hourly classify
+        # interval — the provider must ignore them.
+        runner = self._make_bare_runner(tmp_path)
+        runner.feed_warmup_bars(_klines_15m_days(7))
+        runner.target_interval = 14400  # simulate an H4 donor
+        assert runner._classifier_bars() == []  # no CSVs in this dir
+
+    def test_provider_survives_aggregated_bars_rebind(self, tmp_path):
+        # _rebuild_timeframe REBINDS self._aggregated_bars (issue #43
+        # family) — the provider must read the attribute at call time.
+        runner = self._make_bare_runner(tmp_path)
+        runner.feed_warmup_bars(_klines_15m_days(7))
+        assert len(runner._classifier_bars()) > 0
+        runner._aggregated_bars = []
+        assert runner._classifier_bars() == []
+
+
+class TestSessionPnlWindow:
+    def _trade(self, exit_dt, pnl):
+        from types import SimpleNamespace
+        return SimpleNamespace(exit_dt=exit_dt, pnl=pnl)
+
+    def test_night_window_spans_midnight(self, tmp_path):
+        """Pre-midnight night exits belong to the night session; day
+        trades don't leak in. The old calendar-date match dropped the
+        22:30 trade entirely (session was keyed by the NEXT day's date
+        at the 04:58 record)."""
+        from src.regime.switch_logic import current_session
+        runner = _make_runner(tmp_path)
+        runner.broker.trades.append(self._trade("2026-07-09 22:30", 100.0))
+        runner.broker.trades.append(self._trade("2026-07-10 03:20", 50.0))
+        runner.broker.trades.append(self._trade("2026-07-09 10:00", 999.0))
+        sess = current_session(datetime(2026, 7, 10, 4, 58, tzinfo=_TZ_TAIPEI))
+        assert runner._compute_session_pnl(sess) == (150.0, 2)
+
+    def test_day_window_excludes_night_trades(self, tmp_path):
+        """The old date-only match double-counted post-midnight night
+        exits into the same date's DAY row."""
+        from src.regime.switch_logic import current_session
+        runner = _make_runner(tmp_path)
+        runner.broker.trades.append(self._trade("2026-07-10 03:20", 50.0))
+        runner.broker.trades.append(self._trade("2026-07-10 09:15", 30.0))
+        sess = current_session(datetime(2026, 7, 10, 10, 0, tzinfo=_TZ_TAIPEI))
+        assert runner._compute_session_pnl(sess) == (30.0, 1)
+
+    def test_force_close_seconds_precision(self, tmp_path):
+        # force_close writes "YYYY-MM-DD HH:MM:SS" — must still match.
+        from src.regime.switch_logic import current_session
+        runner = _make_runner(tmp_path)
+        runner.broker.trades.append(self._trade("2026-07-10 10:00:42", 70.0))
+        sess = current_session(datetime(2026, 7, 10, 10, 5, tzinfo=_TZ_TAIPEI))
+        assert runner._compute_session_pnl(sess) == (70.0, 1)
+
+
+class TestStaleRecommendationDiscard:
+    def test_stale_pending_discarded(self, tmp_path):
+        runner = _make_runner(tmp_path)
+        runner._pending_recommendation = {
+            "date": "2026-07-06", "action": "deploy_long",
+            "strategy": "TestLong", "qty_scale": 1.0, "reason": "old",
+        }
+        # Fri 07:00 — the 07-09-open night has completed since 07-06
+        now = datetime(2026, 7, 10, 7, 0, tzinfo=_TZ_TAIPEI)
+        result = runner._maybe_apply_pending(now)
+        assert result is None
+        assert runner._pending_recommendation is None  # dropped, not applied
+        assert runner.active_leg == "idle"
+
+    def test_fresh_pending_still_applies(self, tmp_path):
+        runner = _make_runner(tmp_path)
+        runner._pending_recommendation = {
+            "date": "2026-07-09", "action": "deploy_long",
+            "strategy": "TestLong", "qty_scale": 1.0, "reason": "fresh",
+        }
+        now = datetime(2026, 7, 10, 7, 0, tzinfo=_TZ_TAIPEI)
+        result = runner._maybe_apply_pending(now)
+        assert result is not None
+        assert runner.active_leg == "long"
+
+
+class TestPermanentApplyErrorDiscard:
+    def test_unknown_strategy_discards_pending(self, tmp_path):
+        """A leg strategy missing from the registry is a permanent config
+        error — old code kept the pending armed and errored every 30s
+        poll forever (and re-armed it after every restart)."""
+        runner = _make_runner(tmp_path)
+        runner._long_strategy_name = "Nonexistent"
+        runner._pending_recommendation = {
+            "date": "2026-07-09", "action": "deploy_long",
+            "strategy": "Nonexistent", "qty_scale": 1.0, "reason": "test",
+        }
+        now = datetime(2026, 7, 10, 7, 0, tzinfo=_TZ_TAIPEI)
+        result = runner._maybe_apply_pending(now)
+        assert result is None
+        assert runner._pending_recommendation is None
+        assert runner.active_leg == "idle"
+
+
+class TestStopRecordsForceClose:
+    def test_force_close_trade_included_in_record(self, tmp_path, monkeypatch):
+        """stop() must record AFTER LiveRunner.stop() appends the
+        force-close trade — old code recorded first, permanently losing
+        that trade's P&L from the session row."""
+        import csv as csv_mod
+        from types import SimpleNamespace
+        import src.live.regime_switching_runner as rsr
+        from src.live.live_runner import LiveRunner
+
+        runner = _make_runner(tmp_path)
+        sess = rsr.current_session(
+            datetime(2026, 7, 10, 10, 0, tzinfo=_TZ_TAIPEI))
+        monkeypatch.setattr(rsr, "current_session", lambda now=None: sess)
+
+        def fake_stop(self):
+            self.broker.trades.append(
+                SimpleNamespace(exit_dt="2026-07-10 10:00", pnl=777.0))
+            return {}
+
+        monkeypatch.setattr(LiveRunner, "stop", fake_stop)
+        runner.stop()
+
+        hist = os.path.join(runner.bot_dir, "regime_history.csv")
+        with open(hist, newline="") as f:
+            rows = list(csv_mod.reader(f))
+        match = [r for r in rows[1:]
+                 if r[0] == "2026-07-10" and r[1] == "DAY"]
+        assert len(match) == 1
+        assert match[0][15] == "777.0"  # pnl column

--- a/tests/test_switch_logic.py
+++ b/tests/test_switch_logic.py
@@ -5,10 +5,16 @@ from datetime import datetime, timezone, timedelta
 from src.regime.switch_logic import (
     session_slot,
     in_closed_gap,
-    should_classify,
+    current_session,
+    latest_night_session,
+    last_completed_night,
+    classification_due,
     validate_leg_strategies,
     _TZ_TAIPEI,
 )
+
+# Test-week calendar (2026): 07-09 Thu, 07-10 Fri, 07-11 Sat, 07-12 Sun,
+# 07-13 Mon. No TW public holidays in this range.
 
 
 def _tpe(year, month, day, hour, minute):
@@ -107,28 +113,135 @@ class TestInClosedGap:
         assert in_closed_gap(dt) is True
 
 
-# ── should_classify ──
+# ── current_session (open-date session identity) ──
 
-class TestShouldClassify:
-    def test_fires_on_night_near_close(self):
-        now = _tpe(2026, 7, 10, 4, 58)
-        assert should_classify(now, ("2026-07-10", "NIGHT"), "", 1.5) is True
+class TestCurrentSession:
+    def test_day_session(self):
+        sess = current_session(_tpe(2026, 7, 9, 10, 0))  # Thu 10:00
+        assert (sess.open_date, sess.slot) == ("2026-07-09", "DAY")
+        assert sess.open_dt == _tpe(2026, 7, 9, 8, 45)
+        assert sess.close_dt == _tpe(2026, 7, 9, 13, 45)
 
-    def test_refuses_day_session(self):
-        now = _tpe(2026, 7, 9, 13, 44)
-        assert should_classify(now, ("2026-07-09", "DAY"), "", 1.0) is False
+    def test_night_before_midnight(self):
+        sess = current_session(_tpe(2026, 7, 9, 22, 0))  # Thu 22:00
+        assert (sess.open_date, sess.slot) == ("2026-07-09", "NIGHT")
+        assert sess.close_dt == _tpe(2026, 7, 10, 5, 0)
 
-    def test_refuses_far_from_close(self):
-        now = _tpe(2026, 7, 9, 22, 0)
-        assert should_classify(now, ("2026-07-09", "NIGHT"), "", 60.0) is False
+    def test_night_after_midnight_same_identity(self):
+        # THE root-cause fix: the same night session keeps its OPEN-date
+        # identity on both sides of midnight (old session_slot flipped
+        # the date at 00:00, splitting one session into two keys).
+        before = current_session(_tpe(2026, 7, 9, 23, 59))
+        after = current_session(_tpe(2026, 7, 10, 3, 0))
+        assert before.key == after.key == "2026-07-09|NIGHT"
 
-    def test_dedup_same_key(self):
-        now = _tpe(2026, 7, 10, 4, 58)
-        assert should_classify(now, ("2026-07-10", "NIGHT"), "2026-07-10|NIGHT", 1.5) is False
+    def test_day_gap_returns_none(self):
+        assert current_session(_tpe(2026, 7, 9, 14, 0)) is None
 
-    def test_different_date_key_passes(self):
-        now = _tpe(2026, 7, 10, 4, 58)
-        assert should_classify(now, ("2026-07-10", "NIGHT"), "2026-07-09|NIGHT", 1.5) is True
+    def test_morning_gap_returns_none(self):
+        assert current_session(_tpe(2026, 7, 10, 6, 0)) is None
+
+    def test_at_day_close_returns_none(self):
+        assert current_session(_tpe(2026, 7, 9, 13, 45)) is None
+
+    def test_just_before_day_close(self):
+        sess = current_session(_tpe(2026, 7, 9, 13, 44))
+        assert (sess.open_date, sess.slot) == ("2026-07-09", "DAY")
+
+    def test_saturday_daytime_returns_none(self):
+        # Old code produced a phantom "2026-07-11,DAY" history row from a
+        # Saturday 13:43 poll — Saturday has no DAY session.
+        assert current_session(_tpe(2026, 7, 11, 13, 43)) is None
+
+    def test_saturday_night_carryover(self):
+        # Friday's night session runs until Saturday 05:00.
+        sess = current_session(_tpe(2026, 7, 11, 3, 0))
+        assert (sess.open_date, sess.slot) == ("2026-07-10", "NIGHT")
+
+    def test_sunday_returns_none(self):
+        assert current_session(_tpe(2026, 7, 12, 20, 0)) is None
+
+    def test_monday_early_morning_returns_none(self):
+        # No Sunday-open night session to carry over.
+        assert current_session(_tpe(2026, 7, 13, 3, 0)) is None
+
+    def test_holiday_returns_none(self, monkeypatch):
+        from src.market_data import holidays as hol
+        monkeypatch.setattr(hol, "is_taifex_holiday", lambda d: True)
+        assert current_session(_tpe(2026, 7, 9, 10, 0)) is None
+
+
+# ── latest_night_session / last_completed_night ──
+
+class TestLatestNightSession:
+    def test_in_progress_night(self):
+        sess = latest_night_session(_tpe(2026, 7, 10, 4, 58))  # Fri 04:58
+        assert sess.open_date == "2026-07-09"
+        assert sess.close_dt == _tpe(2026, 7, 10, 5, 0)
+
+    def test_completed_night_during_day(self):
+        sess = latest_night_session(_tpe(2026, 7, 10, 12, 0))  # Fri noon
+        assert sess.open_date == "2026-07-09"
+
+    def test_weekend_holds_friday_night(self):
+        # Sat, Sun, and Mon pre-open all resolve to the Friday-open night.
+        for dt in (_tpe(2026, 7, 11, 12, 0), _tpe(2026, 7, 12, 12, 0),
+                   _tpe(2026, 7, 13, 4, 58)):
+            assert latest_night_session(dt).open_date == "2026-07-10"
+
+    def test_evening_advances_to_new_night(self):
+        sess = latest_night_session(_tpe(2026, 7, 13, 15, 30))  # Mon 15:30
+        assert sess.open_date == "2026-07-13"
+
+
+class TestLastCompletedNight:
+    def test_during_night_returns_previous(self):
+        sess = last_completed_night(_tpe(2026, 7, 9, 22, 0))  # in Thu-open night
+        assert sess.open_date == "2026-07-08"
+
+    def test_after_close_returns_that_night(self):
+        sess = last_completed_night(_tpe(2026, 7, 10, 6, 0))
+        assert sess.open_date == "2026-07-09"
+
+
+# ── classification_due ──
+
+class TestClassificationDue:
+    def test_fires_in_close_window(self):
+        sess = classification_due(_tpe(2026, 7, 10, 4, 58), "")
+        assert sess is not None
+        assert sess.open_date == "2026-07-09"  # keyed by session OPEN date
+
+    def test_dedup_blocks(self):
+        assert classification_due(
+            _tpe(2026, 7, 10, 4, 58), "2026-07-09|NIGHT") is None
+
+    def test_mid_night_not_due(self):
+        # In-progress night, far from close: wait for the close window.
+        assert classification_due(
+            _tpe(2026, 7, 9, 22, 0), "2026-07-08|NIGHT") is None
+
+    def test_catch_up_after_missed_window(self):
+        # App slept across 04:58-05:00: the completed, unassessed night
+        # still classifies later that morning (old code silently skipped
+        # the whole day).
+        sess = classification_due(_tpe(2026, 7, 10, 9, 30), "2026-07-08|NIGHT")
+        assert sess is not None
+        assert sess.open_date == "2026-07-09"
+
+    def test_weekend_polls_inert(self):
+        # Once Friday's night is assessed, Sat/Sun/Mon-morning polls stay
+        # None — old code re-classified the same stale data on Sunday and
+        # Monday 04:58, double-stepping the hysteresis state machine.
+        for dt in (_tpe(2026, 7, 11, 12, 0), _tpe(2026, 7, 12, 4, 58),
+                   _tpe(2026, 7, 13, 4, 58)):
+            assert classification_due(dt, "2026-07-10|NIGHT") is None
+
+    def test_saturday_morning_close_window_fires(self):
+        # Friday's night legitimately closes Saturday 05:00.
+        sess = classification_due(_tpe(2026, 7, 11, 4, 58), "2026-07-09|NIGHT")
+        assert sess is not None
+        assert sess.open_date == "2026-07-10"
 
 
 # ── validate_leg_strategies ──


### PR DESCRIPTION
## Summary

Regime trade attribution work — makes the regime-switching bot correctly attribute trades across legs and report them accurately, plus mixed-timeframe support.

## What was added

- **Aggregator rebuild on swap** — mixed-timeframe support via `_rebuild_timeframe()`, so swapping between legs on different timeframes rebuilds the bar aggregator instead of feeding stale/mismatched bars.
- **Regime-aware report tab header** — shows both legs (long/short) plus the currently active leg, instead of a single-strategy header.
- **Correct Discord deploy notification for regime bots** — dedicated `bot_deployed_regime()` path replaces the generic single-strategy deploy message.
- **Bilingual regime labels and reason strings** in Discord notifications (繁體中文 + English) — commit `c311617`.
- **`validate_leg_strategies()` soft warning** — a timeframe mismatch between legs now emits a soft warning instead of a hard error, allowing intentional mixed-TF regime setups.

## Notes

Built on top of the merged regime Phase 3 work (PR #85).
