### PR TITLE
chore(gitignore): narrow .claude ignore to local config only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,8 +40,9 @@ strategies/
 .DS_Store
 Thumbs.db
 
-# Claude
-.claude/
+# Claude — local/personal config stays out; shared skills/commands/agents are committed
+.claude/settings.local.json
+.claude/worktrees/
 
 # Capital API SDK (large binaries - download separately)
 CapitalAPI_2.13.57/


### PR DESCRIPTION
## What

Narrows the `.gitignore` rule for `.claude/` so it ignores only local/personal config, not the whole directory:

```
.claude/settings.local.json
.claude/worktrees/
```

## Why

`.claude/` was blanket-ignored, which also excluded shared repo assets that are *meant* to be version-controlled (e.g. `.claude/skills/debug/SKILL.md`, and any future commands/agents). Those files currently sit on `master` as *tracked-but-ignored* (force-added), a confusing state. This makes them track normally with no `git add -f`, while keeping personal `settings.local.json` and transient worktree scratch out of git.

Single-file change; no code or behavior affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)